### PR TITLE
Add instructions and capability to install as an unsigned Firefox add-on

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Install Inbox Reborn as an **unpacked extension**:
 
 [Firefox Add-ons: Inbox in Gmail](https://addons.mozilla.org/firefox/addon/inbox-in-gmail)
 
-Install Inbox Reborn as an **unsigned Firefox addon**:
+Install Inbox Reborn as an **unsigned Firefox addon** (sometimes the version on the Firefox add-ons site is out of date):
 1. Download [this repo's source code here](https://github.com/team-inbox/inbox-reborn/archive/master.zip), and unzip it where you like
 2. Create a new zip file of the main folder's content of the zip file, so that there is no containing 'inbox-reborn-master' folder
 3. Make sure the Firefox setting `xpinstall.signatures.required` is set to `false` - this is done in `about:config`

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Install Inbox Reborn as an **unpacked extension**:
 
 [Firefox Add-ons: Inbox in Gmail](https://addons.mozilla.org/firefox/addon/inbox-in-gmail)
 
+Install Inbox Reborn as an **unsigned Firefox addon**:
+1. Download [this repo's source code here](https://github.com/team-inbox/inbox-reborn/archive/master.zip), and unzip it where you like
+2. Create a new zip file of the main folder's content of the zip file, so that there is no containing 'inbox-reborn-master' folder
+3. Make sure the Firefox setting `xpinstall.signatures.required` is set to `false` - this is done in `about:config`
+4. On the Firefox addons page, use the "Install Add-on From File..." on the gear menu to install the addon from the zip file you just created
+
 
 ## Features
 

--- a/manifest.json
+++ b/manifest.json
@@ -4,6 +4,11 @@
   "manifest_version": 2,
   "description": "Adds features like reminders, email bundling and Inbox's minimalistic style to Gmail™",
   "homepage_url": "https://github.com/team-inbox/inbox-reborn",
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "inbox-reborn@team-inbox.github.io"
+    }
+  },
   "browser_action": {
     "default_popup": "src/options/options.html"
   },


### PR DESCRIPTION
Due to the fact that the version on the Firefox add-ons site is sometimes out of date, I thought it was a good idea to make the add-on installable as an unsigned add-on so that users can easily have the latest version.