### PR TITLE
Add option to not bundle labels if they contain only one mail

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Install Inbox Reborn as an **unpacked extension**:
 
 Install Inbox Reborn as an **unsigned Firefox addon** (sometimes the version on the Firefox add-ons site is out of date):
 1. Download [this repo's source code here](https://github.com/team-inbox/inbox-reborn/archive/master.zip), and unzip it where you like
-2. Create a new zip file of the main folder's content of the zip file, so that there is no containing 'inbox-reborn-master' folder
+2. Create a new zip file of the main folder's content, so that there is no containing 'inbox-reborn-master' folder
 3. Make sure the Firefox setting `xpinstall.signatures.required` is set to `false` - this is done in `about:config`
 4. On the Firefox addons page, use the "Install Add-on From File..." on the gear menu to install the addon from the zip file you just created
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Inbox Reborn theme for Gmail™",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "manifest_version": 2,
   "description": "Adds features like reminders, email bundling and Inbox's minimalistic style to Gmail™",
   "homepage_url": "https://github.com/team-inbox/inbox-reborn",

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -22,6 +22,8 @@
             <input type="radio" name="email-bundling" value="enabled"> Enabled
             <br />
             <input type="radio" name="email-bundling" value="disabled"> Disabled
+            <br /><br />
+            <input type="checkbox" name="bundle-one" checked="checked"> Bundle if only one email?
         </div>
     </div>
     <div class="setting">

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -23,7 +23,7 @@
             <br />
             <input type="radio" name="email-bundling" value="disabled"> Disabled
             <br /><br />
-            <input type="checkbox" name="bundle-one" checked="checked"> Bundle if only one email?
+            <input type="checkbox" name="bundle-one" checked="checked"> Bundle if only one email? (requires refresh when switching off)
         </div>
     </div>
     <div class="setting">

--- a/src/options/script.js
+++ b/src/options/script.js
@@ -1,13 +1,15 @@
 const REMINDER_TREATMENT_SELECTOR = 'input[name=reminder-treatment]';
 const BUNDLED_EMAIL_SELECTOR = 'input[name=email-bundling]';
 const AVATAR_SELECTOR = 'input[name=avatar]';
+const BUNDLE_ONE_SELECTOR = 'input[name=bundle-one]';
 
 function saveOptions() {
 	const reminderTreatment = getSelectedRadioValue(REMINDER_TREATMENT_SELECTOR);
 	const emailBundling = getSelectedRadioValue(BUNDLED_EMAIL_SELECTOR);
 	const showAvatar = getSelectedRadioValue(AVATAR_SELECTOR);
+	const bundleOne = getCheckboxState(BUNDLE_ONE_SELECTOR);
 
-	const options = { reminderTreatment, emailBundling, showAvatar };
+	const options = { reminderTreatment, emailBundling, showAvatar, bundleOne };
 
 	localStorage.setItem('options', JSON.stringify(options));
 }
@@ -17,6 +19,7 @@ function restoreOptions() {
 		selectRadioWithValue(REMINDER_TREATMENT_SELECTOR, options.reminderTreatment);
 		selectRadioWithValue(BUNDLED_EMAIL_SELECTOR, options.emailBundling);
 		selectRadioWithValue(AVATAR_SELECTOR, options.showAvatar);
+		setCheckbox(BUNDLE_ONE_SELECTOR, options.bundleOne);
 	});
 }
 
@@ -26,7 +29,12 @@ function selectRadioWithValue(selector, value) {
 	});
 }
 
+function setCheckbox(selector, value) {
+	document.querySelector(selector).checked = !!value;
+}
+
 const getSelectedRadioValue = selector => document.querySelector(selector + ':checked').value;
+const getCheckboxState = selector => document.querySelector(selector).checked;
 
 const monitorChange = element => element.addEventListener('click', saveOptions);
 
@@ -34,3 +42,4 @@ document.addEventListener('DOMContentLoaded', restoreOptions);
 document.querySelectorAll(REMINDER_TREATMENT_SELECTOR).forEach(monitorChange);
 document.querySelectorAll(BUNDLED_EMAIL_SELECTOR).forEach(monitorChange);
 document.querySelectorAll(AVATAR_SELECTOR).forEach(monitorChange);
+monitorChange(document.querySelector(BUNDLE_ONE_SELECTOR));

--- a/src/script.js
+++ b/src/script.js
@@ -632,7 +632,16 @@ const updateReminders = () => {
 				continue;
 			}
 
-			const labels = emailInfo.labels.filter(x => !tabs.includes(x));
+			let labelCounts = emails.reduce((counts, email) => {
+				email.labels.forEach(label => counts[label] = ~~counts[label] + 1)
+				return counts;
+			}, {});
+			let labelsToBundle = [];
+			for (label in labelCounts) if (labelCounts[label] > 1) labelsToBundle.push(label);
+
+			let labels = emailInfo.labels.filter(x => !tabs.includes(x));
+			labels = labels.filter(x => labelsToBundle.includes(x));
+
 			if (isInInboxFlag && !emailInfo.isStarred && labels.length && !emailInfo.isUnbundled && !emailInfo.bundleAlreadyProcessed()) {
 				labels.forEach(label => {
 					addClassToEmail(emailEl, BUNDLED_EMAIL_CLASS);

--- a/src/script.js
+++ b/src/script.js
@@ -632,15 +632,17 @@ const updateReminders = () => {
 				continue;
 			}
 
-			let labelCounts = emails.reduce((counts, email) => {
-				email.labels.forEach(label => counts[label] = ~~counts[label] + 1)
-				return counts;
-			}, {});
 			let labelsToBundle = [];
-			for (label in labelCounts) if (labelCounts[label] > 1) labelsToBundle.push(label);
+			if (!options.bundleOne) {
+				let labelCounts = emails.reduce((counts, email) => {
+					email.labels.forEach(label => counts[label] = ~~counts[label] + 1)
+					return counts;
+				}, {});
+				for (label in labelCounts) if (labelCounts[label] > 1) labelsToBundle.push(label);
+			}
 
 			let labels = emailInfo.labels.filter(x => !tabs.includes(x));
-			labels = labels.filter(x => labelsToBundle.includes(x));
+			if (!options.bundleOne && labelsToBundle.length) labels = labels.filter(x => labelsToBundle.includes(x));
 
 			if (isInInboxFlag && !emailInfo.isStarred && labels.length && !emailInfo.isUnbundled && !emailInfo.bundleAlreadyProcessed()) {
 				labels.forEach(label => {


### PR DESCRIPTION
I was finding it kind of annoying to have to 'open' a bundle then open the single email when that bundle only had one email, so I made it so you can have single emails not be bundled.

This could be made better by making bundles 'unbundle' if you delete mails so that the bundle is back down to 1 email. I haven't looked at how easy/hard that part is - hopefully not too difficult

Is this a good addition?