### PR TITLE
Make floating buttons jive with add-on side panels

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -866,7 +866,7 @@ const sidePanelHandler = () => {
 
 		sidePanelBtns[b].addEventListener('click', function(e) {
 			moveFloatersLeft();
-			sidePanelCloseHandler();
+			sidePanelMutationHandler();
 		});
 	}
 
@@ -875,14 +875,14 @@ const sidePanelHandler = () => {
 	if(!addOnsFrame.classList.contains('br9')) {
 
 		moveFloatersLeft();
-		sidePanelCloseHandler();
+		sidePanelMutationHandler();
 	}
 
 }
 
-const sidePanelCloseHandler = () => {
 	console.log('AddOnsBar: ready to close it down');
 	
+const sidePanelMutationHandler = () => {
 	// Only one is active in DOM at a time... hence no 'All'
 	const addOnsPanels = document.querySelector('.bq9.buW > .brC-brG > div');
 	
@@ -892,7 +892,7 @@ const sidePanelCloseHandler = () => {
 		attributeFilter: ['style']
 	};
 
-	const panelClosed = (mutationsList, addOnsObserver) => {
+	const panelMutated = (mutationsList, addOnsObserver) => {
 		for(const mutagen of mutationsList) {
 			if(mutagen.type === 'attributes') {
 				moveFloatersRight();
@@ -900,7 +900,7 @@ const sidePanelCloseHandler = () => {
 		}
 	}
 
-	const addOnsObserver = new MutationObserver(panelClosed);
+	const addOnsObserver = new MutationObserver(panelMutated);
 
 	addOnsObserver.observe(addOnsPanels, addOnsObserverConfig);
 		

--- a/src/script.js
+++ b/src/script.js
@@ -839,7 +839,79 @@ document.addEventListener('DOMContentLoaded', function () {
 	document.body.appendChild(floatingComposeButton);
 
 	setInterval(updateReminders, 250);
+
+  waitForElement('div[aria-label="Side panel"] .bse-bvF-I.aT5-aOt-I', sidePanelHandler);
+
 });
+
+const moveFloatersLeft = () => {
+	document.querySelector('.add-reminder').classList.add('moved');
+	document.querySelector('.floating-compose').classList.add('moved');
+}
+const moveFloatersRight = () => {
+	document.querySelector('.add-reminder').classList.remove('moved');
+	document.querySelector('.floating-compose').classList.remove('moved');
+
+	addOnsObserver.disconnect();
+}
+
+const sidePanelHandler = () => {
+
+	const sidePanel = document.querySelector('div[aria-label="Side panel"');
+	const sidePanelBtns = sidePanel.querySelectorAll('.bse-bvF-I.aT5-aOt-I:not(#qJTzr)'); // ignore the + btn
+
+	const addOnsFrame = document.querySelector('.bq9.buW');
+
+	for(let b = 0; b < sidePanelBtns.length; b++) {
+
+		sidePanelBtns[b].addEventListener('click', function(e) {
+			moveFloatersLeft();
+			sidePanelCloseHandler();
+		});
+	}
+
+	// AddOn open at page load check
+
+	if(!addOnsFrame.classList.contains('br9')) {
+
+		moveFloatersLeft();
+		sidePanelCloseHandler();
+	}
+
+}
+
+const sidePanelCloseHandler = () => {
+	console.log('AddOnsBar: ready to close it down');
+	
+	// Only one is active in DOM at a time... hence no 'All'
+	const addOnsPanels = document.querySelector('.bq9.buW > .brC-brG > div');
+	
+	const addOnsObserverConfig = {
+		attributes: true,
+		childList: true,
+		attributeFilter: ['style']
+	};
+
+	const panelClosed = (mutationsList, addOnsObserver) => {
+		for(const mutagen of mutationsList) {
+			console.log(mutagen);
+
+			if(mutagen.type === 'attributes') {
+				console.log('AddOnsBar: attr mutation ahoy!');
+				moveFloatersRight();
+			} else {
+				console.log('AddOnsBar: other mutations afoot!');
+			}
+
+			console.log('mutagens plz?');
+		}
+	}
+
+	const addOnsObserver = new MutationObserver(panelClosed);
+
+	addOnsObserver.observe(addOnsPanels, addOnsObserverConfig);
+		
+}
 
 const setFavicon = () => document.querySelector('link[rel*="shortcut icon"]').href = chrome.runtime.getURL('images/favicon.png');;
 

--- a/src/script.js
+++ b/src/script.js
@@ -894,16 +894,9 @@ const sidePanelCloseHandler = () => {
 
 	const panelClosed = (mutationsList, addOnsObserver) => {
 		for(const mutagen of mutationsList) {
-			console.log(mutagen);
-
 			if(mutagen.type === 'attributes') {
-				console.log('AddOnsBar: attr mutation ahoy!');
 				moveFloatersRight();
-			} else {
-				console.log('AddOnsBar: other mutations afoot!');
 			}
-
-			console.log('mutagens plz?');
 		}
 	}
 

--- a/src/style.css
+++ b/src/style.css
@@ -1373,6 +1373,14 @@ body.email-bundling-enabled.bundle-page .nH.ar4.B .yi {
 	order: 1 !important;
 }
 
+.add-reminder.moved {
+	right: 348px;
+}
+
+.floating-compose.moved {
+	right: 340px;
+}
+
 
 /* Hide Compose and Reminder buttons from Gmail's Print view */
 @media print {


### PR DESCRIPTION
So I've been using the calendar add-on panel on the right for quick event creation and noticed the floating compose + reminder buttons were getting in the way of the Save button.

⚠️ This works flawlessly as long as you enter the page with the panel closed, otherwise, an open/close cycle is required to get things moving as intended.

I'd love for a fresh set of eyes on this and am certainly open to feedback/criticisms /et cetera in order to improve anything! Was great to experiment using `MutationObserver` ..although, currently, am not having luck observing the first mutation in the aforementioned scenario. ☝🏻