### PR TITLE
Add hotfix for Google Chat status selector

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Inbox Reborn theme for Gmail™",
-  "version": "0.5.9",
+  "version": "0.5.9.1",
   "manifest_version": 2,
   "description": "Adds features like reminders, email bundling and Inbox's minimalistic style to Gmail™",
   "homepage_url": "https://github.com/team-inbox/inbox-reborn",

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Inbox Reborn theme for Gmail™",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "manifest_version": 2,
   "description": "Adds features like reminders, email bundling and Inbox's minimalistic style to Gmail™",
   "homepage_url": "https://github.com/team-inbox/inbox-reborn",

--- a/src/script.js
+++ b/src/script.js
@@ -879,8 +879,6 @@ const sidePanelHandler = () => {
 	}
 
 }
-
-	console.log('AddOnsBar: ready to close it down');
 	
 const sidePanelMutationHandler = () => {
 	// Only one is active in DOM at a time... hence no 'All'

--- a/src/style.css
+++ b/src/style.css
@@ -767,8 +767,14 @@ header svg {
 	opacity: 1 !important;
 }
 
-/* Top bar Google Chat status selector text */
-.Yc {
+/* Top bar Google Chat status selector */
+.Yb, .Yb:not(.abs):focus {
+	border-color: transparent !important;
+}
+.Yb[aria-label="Status: Active"] .Yg { /* (Active) Icon */
+	background-color: #34d058 !important;
+}
+.Yc { /* Text */
 	color: #FFF !important;
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -767,6 +767,11 @@ header svg {
 	opacity: 1 !important;
 }
 
+/* Top bar Google Chat status selector text */
+.Yc {
+	color: #FFF !important;
+}
+
 /* Search bar (old, new) */
 header form {
 	background: rgba(255, 255, 255, 0.125) !important;


### PR DESCRIPTION
I prematurely switched from Hangouts Classic feature after prompted of it sun setting later this year, so I enabled the Google Chat (early access) option in Gmail to see what the future holds.

Status selector text color was set to a dark gray, this sets it to white to be moar better.