### PR TITLE
Fix reminder functionality and options page cleanup + Firefox fixes

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Inbox Reborn theme for Gmail™",
-  "version": "0.5.9.1",
+  "version": "0.5.9.2",
   "manifest_version": 2,
   "description": "Adds features like reminders, email bundling and Inbox's minimalistic style to Gmail™",
   "homepage_url": "https://github.com/team-inbox/inbox-reborn",

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-<head><title>Inbox In Gmail Options</title></head>
+<head><title>Inbox in Gmail Options</title></head>
 <link rel="stylesheet" href="style.css">
 <body>
 <div class="content">
@@ -8,31 +8,31 @@
         <div class="setting-title">Reminders</div>
         <div class="setting-content">
             Choose how to display emails sent to yourself<br /><br />
-            <input type="radio" name="reminder-treatment" value="all"> All are treated as reminders.
+            <input type="radio" name="reminder-treatment" value="all" id="reminder-treatment-all"><label for="reminder-treatment-all">All are treated as reminders</label>
             <br />
-            <input type="radio" name="reminder-treatment" value="containing-word"> Only emails with a subject containing the word "reminder" are treated as reminders.
+            <input type="radio" name="reminder-treatment" value="containing-word" id="reminder-treatment-containing-word"><label for="reminder-treatment-containing-word">Those with a subject containing "reminder" are treated as such</label>
             <br />
-            <input type="radio" name="reminder-treatment" value="none"> Leave the emails as they are.
+            <input type="radio" name="reminder-treatment" value="none" id="reminder-treatment-none"><label for="reminder-treatment-none">Leave the emails as they are</label>
         </div>
     </div>
     <div class="setting">
         <div class="setting-title">Email Bundling</div>
         <div class="setting-content">
             Bundles emails in your inbox by label<br /><br />
-            <input type="radio" name="email-bundling" value="enabled"> Enabled
+            <input type="radio" name="email-bundling" value="enabled" id="bundling-on"><label for="bundling-on">Enabled</label>
             <br />
-            <input type="radio" name="email-bundling" value="disabled"> Disabled
+            <input type="radio" name="email-bundling" value="disabled" id="bundling-off"><label for="bundling-off">Disabled</label>
             <br /><br />
-            <input type="checkbox" name="bundle-one" checked="checked"> Bundle if only one email? (requires refresh when switching off)
+            <input type="checkbox" name="bundle-one" checked="checked" id="bundle-one"><label for="bundle-one">Bundle if only one email? (requires refresh when switching off)</label>
         </div>
     </div>
     <div class="setting">
         <div class="setting-title">Avatars</div>
         <div class="setting-content">
             Displays a colored circle with the first letter initial of the sender<br /><br />
-            <input type="radio" name="avatar" value="enabled"> Enabled
+            <input type="radio" name="avatar" value="enabled" id="avatar-on"><label for="avatar-on">Enabled</label>
             <br />
-            <input type="radio" name="avatar" value="disabled"> Disabled
+            <input type="radio" name="avatar" value="disabled" id="avatar-off"><label for="avatar-off">Disabled</label>
         </div>
     </div>
 </div>

--- a/src/options/style.css
+++ b/src/options/style.css
@@ -1,20 +1,23 @@
 body {
-    background-color: rgb(242, 242, 242);
     font-family: Roboto, system-ui, sans-serif;
     font-size: 13px;
     margin: 0;
 }
 
-h1 {
-    font-size: 1.5em;
-    margin: 0 0 20px 0;
-}
-
 .content {
-    box-shadow: rgb(224, 224, 224) 0px -1px 0px, rgba(0, 0, 0, 0.12) 0px 0px 2px, rgba(0, 0, 0, 0.24) 0px 2px 4px !important;
     background-color: white;
     padding: 0 20px;
     width: 550px;
+    max-width:100%;
+    box-sizing: border-box;
+}
+
+label{
+    display:inline-block;
+    width: 90%;
+    vertical-align:top;
+    padding-top: 0.2em;
+    padding-left: 2px;
 }
 
 .settings-wrapper {
@@ -24,7 +27,12 @@ h1 {
 .setting {
     padding: 12px 20px;
     border-bottom: 1px solid rgb(224, 224, 224);
-    margin: 0 -20px;
+    margin: 0 -10px 0 -20px;
+}
+
+.setting:nth-last-child(1) {
+    border-bottom:none;
+    padding-bottom:30px;
 }
 
 .setting-title {
@@ -36,20 +44,3 @@ h1 {
     color: #616161;
 }
 
-button.save {
-    float: right;
-    font-size: 14px;
-    margin-top: 12px;
-
-    color: #fff;
-    background-color: #007bff;
-    border-color: #007bff;
-    border-radius: .25rem;
-    padding: .375rem .75rem;
-}
-
-.clearfix::after {
-    content: "";
-    clear: both;
-    display: table;
-}

--- a/src/script.js
+++ b/src/script.js
@@ -27,7 +27,7 @@ const STYLE_NODE_ID_PREFIX = 'hide-email-';
 // reliable retrieval methods like:
 // gmail.compose.start_compose() via the Gmail.js lib
 let select = {
-    emailAddress:        ()=>document.querySelector('.gb_vb'),
+    emailAddress:        ()=>document.querySelector('.gb_ob'),
     tabs:                ()=>document.querySelectorAll('.aKz'),
     bundleWrappers:      ()=>document.querySelectorAll('.BltHke[role=main] .bundle-wrapper'),
     inbox:               ()=>document.querySelector('.nZ[data-tooltip=Inbox]'),


### PR DESCRIPTION
This should:
* Fix the reminder functionality (which I've never seen working before)
* Fix the options layout in Firefox when addon is in overflow menu (scroll bars were appearing before)
* Improve the options UI slightly with clickable labels