### PR TITLE
Fix for "Inbox Tips" and other alerts

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Inbox Reborn theme for Gmail™",
-  "version": "0.5.9.2",
+  "version": "0.5.9.3",
   "manifest_version": 2,
   "description": "Adds features like reminders, email bundling and Inbox's minimalistic style to Gmail™",
   "homepage_url": "https://github.com/team-inbox/inbox-reborn",

--- a/src/style.css
+++ b/src/style.css
@@ -1392,6 +1392,18 @@ body.email-bundling-enabled.bundle-page .nH.ar4.B .yi {
 	right: 340px;
 }
 
+/* Inbox tips, Unsubscribe/other alerts shown on top */
+.S4 .X3 {
+	margin-left: 9px;
+	margin-right: 9px;
+}
+
+.G4, .GR, div[aria-label="Inbox tip"] {
+	border: 0 !important;
+	border-radius: 0 !important;
+	box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0,0,0,.12), 0 2px 4px rgba(0,0,0,.24) !important;
+}
+
 
 /* Hide Compose and Reminder buttons from Gmail's Print view */
 @media print {


### PR DESCRIPTION
Noticed that these were misaligned and also made their border treatment match the rest of the inbox.

Screenshots below for clarity since these only appear conditionally..

Before:
![Before Screenshot](https://user-images.githubusercontent.com/2481672/122112687-b8b56580-cde6-11eb-9d53-ab274ff09834.png)

After:
![After Screenshot](https://user-images.githubusercontent.com/2481672/122112720-c23ecd80-cde6-11eb-979c-f6e7bef4720e.png)

