### PR TITLE
Changes Logic for Finance and Travel/Trips Labels

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Inbox Reborn theme for Gmail™",
-  "version": "0.5.9.5",
+  "version": "0.5.9.6",
   "manifest_version": 2,
   "description": "Adds features like reminders, email bundling and Inbox's minimalistic style to Gmail™",
   "homepage_url": "https://github.com/team-inbox/inbox-reborn",

--- a/src/script.js
+++ b/src/script.js
@@ -318,7 +318,7 @@ const getBundleImageForLabel = (label) => {
 	switch (true) {
 		case label=='Promotions':
 			return chrome.runtime.getURL('images/ic_offers_24px_clr_r3_2x.png');
-		case label=='Finance':
+		case !!label.match(/\b(finance|finances|banking|tax|taxes)\b/gi):
 			return chrome.runtime.getURL('images/ic_finance_24px_clr_r3_2x.png');
 		case ['Orders', 'Purchases'].includes(label):
 			return chrome.runtime.getURL('images/ic_purchases_24px_clr_r3_2x.png');

--- a/src/script.js
+++ b/src/script.js
@@ -318,7 +318,7 @@ const getBundleImageForLabel = (label) => {
 	switch (true) {
 		case label=='Promotions':
 			return chrome.runtime.getURL('images/ic_offers_24px_clr_r3_2x.png');
-		case !!label.match(/\b(finance|finances|banking|tax|taxes)\b/gi):
+		case !!label.match(/\b(finance|finances|banking|bank|tax|taxes)\b/gi):
 			return chrome.runtime.getURL('images/ic_finance_24px_clr_r3_2x.png');
 		case ['Orders', 'Purchases'].includes(label):
 			return chrome.runtime.getURL('images/ic_purchases_24px_clr_r3_2x.png');

--- a/src/style.css
+++ b/src/style.css
@@ -734,7 +734,7 @@ a[title="Gmail"]::after {
 	padding-left: 7px;
 }
 
-a[title="Gmail"][href="#inbox"]::after {
+a[title="Gmail"][href="#inbox"]::after, a[title="Gmail"][href="#settings"]::after {
 	content: 'Inbox';
 }
 a[title="Gmail"][href="#snoozed"]::after {
@@ -769,9 +769,6 @@ a[title="Gmail"][href="#spam"]::after {
 }
 a[title="Gmail"][href="#trash"]::after {
 	content: 'Trash';
-}
-a[title="Gmail"][href="#settings"]::after {
-	content: 'Settings';
 }
 
 /* Invisible inbox info with huge padding at bottom of email  */


### PR DESCRIPTION
Since "Finance", "Travel", and "Trips" are internal GMail labels that cannot be made viewable in the GMail settings, it seems that the code as it was would never actually show the Finance or Trips icons.

I've modified the logic for these icons so that:

* Travel icon will show if the label contains any of the words: `Trip`, `Trips`, `Travel`
* Finance icon will show if the label contains any of: `Tax`, `Taxes`, `Bank`, `Banking`, `Finance`

Interestingly, behind the scenes, GMail is still intelligently applying these Travel, Trips, Finance labels... but since the demise of Inbox there appears to be no way to view them (although you can search for `label:travel` etc.)

<img width="253" alt="image" src="https://user-images.githubusercontent.com/1510194/140600534-387492d4-d401-4445-abfe-cecb54fd2088.png">
