### PR TITLE
Add hotfix for ginormous image heights

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Inbox Reborn theme for Gmail™",
-  "version": "0.5.9.6",
+  "version": "0.5.9.7",
   "manifest_version": 2,
   "description": "Adds features like reminders, email bundling and Inbox's minimalistic style to Gmail™",
   "homepage_url": "https://github.com/team-inbox/inbox-reborn",

--- a/src/style.css
+++ b/src/style.css
@@ -948,6 +948,7 @@ header form input {
 /* Fix bug that would expand the message area if giant image in message */
 .Bs.nH.iY.bAt img {
 	max-width: 100%;
+	height: auto !important; /* Now ft. actual image proportions! */
 }
 
 /* Fixed border on email */


### PR DESCRIPTION
Patch for a half-assed hotfix I submitted previously..
Huge images should now use proper proportions when scaled to fit in email message area