### PR TITLE
Fixing permissions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Inbox Reborn theme for Gmail™",
-  "version": "0.5.9.13",
+  "version": "0.5.9.14",
   "manifest_version": 2,
   "description": "Adds features like reminders, email bundling and Inbox's minimalistic style to Gmail™",
   "homepage_url": "https://github.com/team-inbox/inbox-reborn",
@@ -20,9 +20,6 @@
     "scripts": ["src/background.js"],
     "persistent": false
   },
-  "permissions": [
-    "storage"
-  ],
   "icons": {
     "16": "icons/icon16.png",
     "48": "icons/icon48.png",


### PR DESCRIPTION
As part of the changes to stop us getting booted from the Chrome store, I removed the 'storage' permission as a test. Everything seems to still work... I don't think we need that permission.