### PR TITLE
A more robust fix (hopefully) for the CSS selector for 'emailAddress'

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Web extension which modifies Gmail™ to bring back the features and uncluttered
 
 ### Chrome & Microsoft Edge 
 
-The extension has been updated to version 0.5.9.17. It can be added through the following link
+The extension has been updated to version 0.5.9.18. It can be added through the following link
 
 https://chrome.google.com/webstore/detail/inbox-reborn-theme-for-gm/bkphmihkdbdgedlaflnkhnmnmibffomf
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Inbox Reborn theme for Gmail™",
-  "version": "0.5.9.20",
+  "version": "0.5.9.21",
   "manifest_version": 2,
   "description": "Adds features like reminders, email bundling and Inbox's minimalistic style to Gmail™",
   "homepage_url": "https://github.com/team-inbox/inbox-reborn",

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Inbox Reborn theme for Gmail™",
-  "version": "0.5.9.17",
+  "version": "0.5.9.18",
   "manifest_version": 2,
   "description": "Adds features like reminders, email bundling and Inbox's minimalistic style to Gmail™",
   "homepage_url": "https://github.com/team-inbox/inbox-reborn",

--- a/src/script.js
+++ b/src/script.js
@@ -27,7 +27,7 @@ const STYLE_NODE_ID_PREFIX = 'hide-email-';
 // reliable retrieval methods like:
 // gmail.compose.start_compose() via the Gmail.js lib
 let select = {
-    emailAddress:        ()=>document.querySelector('.gb_e.gb_0a.gb_r'),
+    emailAddress:        ()=>document.querySelector("a[aria-label^='Google Account:']"),
     tabs:                ()=>document.querySelectorAll('.aKz'),
     bundleWrappers:      ()=>document.querySelectorAll('.BltHke[role=main] .bundle-wrapper'),
     inbox:               ()=>document.querySelector('.nZ[data-tooltip=Inbox]'),

--- a/src/script.js
+++ b/src/script.js
@@ -27,7 +27,7 @@ const STYLE_NODE_ID_PREFIX = 'hide-email-';
 // reliable retrieval methods like:
 // gmail.compose.start_compose() via the Gmail.js lib
 let select = {
-    emailAddress:        ()=>document.querySelector('.gb_d.gb_Ra.gb_l'),
+    emailAddress:        ()=>document.querySelector('.gb_e.gb_Xa.gb_o'),
     tabs:                ()=>document.querySelectorAll('.aKz'),
     bundleWrappers:      ()=>document.querySelectorAll('.BltHke[role=main] .bundle-wrapper'),
     inbox:               ()=>document.querySelector('.nZ[data-tooltip=Inbox]'),
@@ -832,7 +832,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
   setInterval(updateReminders, 250);
 
-  waitForElement('div[aria-label="Side panel"] .bse-bvF-I.aT5-aOt-I[aria-label="Get Add-ons"]', sidePanelHandler);
+  waitForElement('div[aria-label="Side panel"] .bse-bvF-I.aT5-aOt-I[aria-label="Get add-ons"]', sidePanelHandler);
 });
 
 const addFloatingComposeButton = () => {
@@ -855,10 +855,12 @@ const moveFloatersLeft = () => {
 const moveFloatersRight = () => {
 	document.querySelector('.add-reminder').classList.remove('moved');
 	document.querySelector('.floating-compose').classList.remove('moved');
+
+	addOnsObserver.disconnect();
 }
 
 const sidePanelHandler = () => {
-	const sidePanel = document.querySelector('div[aria-label="Side panel"]');
+	const sidePanel = document.querySelector('div[aria-label="Side panel"');
 	const sidePanelBtns = sidePanel.querySelectorAll('.bse-bvF-I.aT5-aOt-I:not(#qJTzr)'); // ignore the + btn
 	const addOnsFrame = document.querySelector('.bq9.buW');
 
@@ -872,7 +874,7 @@ const sidePanelHandler = () => {
 
 	// AddOn open at page load check
 	if(addOnsFrame) {
-		if(!addOnsFrame.classList.contains('br3')) {
+		if(!addOnsFrame.classList.contains('br9')) {
 			moveFloatersLeft();
 			sidePanelMutationHandler();
 		}
@@ -881,19 +883,18 @@ const sidePanelHandler = () => {
 	
 const sidePanelMutationHandler = () => waitForElement('.bq9.buW', () => {
 	const addOnsPanel = document.querySelector('.bq9.buW');
-	const panelResized = new ResizeObserver((entries) => {
-		for (let entry of entries) {	
-			if (entry.contentRect.width == 0) {
-				moveFloatersRight();
-			} else {
-				moveFloatersLeft();
+	const panelResized = entries => {
+		for (let entry of entries) {
+			if (entry.contentRect.width==0) {
+				moveFloatersRight()
 			}
 		}
-	});
-	panelResized.observe(addOnsPanel);
+	}
+	const addOnsObserver = new ResizeObserver(panelResized)
+	addOnsObserver.observe(addOnsPanel)		
 })
 
-const setFavicon = () => document.querySelector('link[rel*="shortcut icon"]').href = chrome.runtime.getURL('images/favicon.png');
+const setFavicon = () => document.querySelector('link[rel*="shortcut icon"]').href = chrome.runtime.getURL('images/favicon.png');;
 
 const init = () => {
 	setFavicon();


### PR DESCRIPTION
As Google seem to keep changing the classes for this, maybe using the aria-label will mean less updating of the addon? I was mildly concerned that this might make functionality English specific, but we're already using some English text in other CSS selectors