### PR TITLE
A more robust fix (hopefully) for the CSS selector for 'emailAddress'

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Web extension which modifies Gmail™ to bring back the features and uncluttered
 
 ### Chrome & Microsoft Edge 
 
-The extension has been updated to version 0.5.9.20. It can be added through the following link
+The extension has been updated to version 0.5.9.21. It can be added through the following link
 
 https://chrome.google.com/webstore/detail/inbox-reborn-theme-for-gm/bkphmihkdbdgedlaflnkhnmnmibffomf
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Inbox Reborn theme for Gmail™",
-  "version": "0.5.9.20",
+  "version": "0.5.9.21",
   "manifest_version": 2,
   "description": "Adds features like reminders, email bundling and Inbox's minimalistic style to Gmail™",
   "homepage_url": "https://github.com/team-inbox/inbox-reborn",

--- a/src/script.js
+++ b/src/script.js
@@ -27,7 +27,7 @@ const STYLE_NODE_ID_PREFIX = 'hide-email-';
 // reliable retrieval methods like:
 // gmail.compose.start_compose() via the Gmail.js lib
 let select = {
-    emailAddress:        ()=>document.querySelector('.gb_e.gb_0a.gb_r'),
+    emailAddress:        ()=>document.querySelector("a[aria-label^='Google Account:']"),
     tabs:                ()=>document.querySelectorAll('.aKz'),
     bundleWrappers:      ()=>document.querySelectorAll('.BltHke[role=main] .bundle-wrapper'),
     inbox:               ()=>document.querySelector('.nZ[data-tooltip=Inbox]'),


### PR DESCRIPTION
As Google seem to keep changing the classes for this, maybe using the aria-label will mean less updating of the addon? I was mildly concerned that this might make functionality English specific, but we're already using some English text in other CSS selectors.

I also noticed that the sidebar is broken again, and sending reminders no longer works... joy :(