### PR TITLE
Fix label colours (everywhere) + bundle colours (Firefox) + a new error

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Web extension which modifies Gmail™ to bring back the features and uncluttered
 
 ### Chrome & Microsoft Edge 
 
-The extension has been updated to version 0.5.9.25. It can be added through the following link
+The extension has been updated to version 0.5.9.26. It can be added through the following link
 
 https://chrome.google.com/webstore/detail/inbox-reborn-theme-for-gm/bkphmihkdbdgedlaflnkhnmnmibffomf
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Inbox Reborn theme for Gmail™",
-  "version": "0.5.9.25",
+  "version": "0.5.9.26",
   "manifest_version": 2,
   "description": "Adds features like reminders, email bundling and Inbox's minimalistic style to Gmail™",
   "homepage_url": "https://github.com/team-inbox/inbox-reborn",

--- a/src/script.js
+++ b/src/script.js
@@ -350,12 +350,26 @@ const getBundleTitleColorForLabel = (email, label) => {
 	return bundleTitleColor;
 };
 
+const getCategoryColor = label => ({
+	Updates: 'rgb(255, 104, 57)',
+	Promotions: 'rgb(0, 188, 212)',
+	Forums: 'rgb(63, 81, 181)',
+	Social: 'rgb(219, 68, 55)',
+	Travel: 'rgb(156, 39, 176)',
+	Trips: 'rgb(156, 39, 176)',
+	Finance: 'rgb(103, 159, 56)',
+	Orders: 'rgb(121, 85, 72)',
+	Purchases: 'rgb(121, 85, 72)',
+}[label] || '#616161');
+
 const buildBundleWrapper = function (email, label, hasImportantMarkers) {
 	const importantMarkerClass = hasImportantMarkers ? '' : 'hide-important-markers';
 	const bundleImage = getBundleImageForLabel(label);
 	const bundleTitleColor = bundleImage.match(/custom-cluster/) && getBundleTitleColorForLabel(email, label);
 
-	const style = `-webkit-mask: url(${bundleImage}) 0 0/100% 100%; background-color: ${bundleTitleColor};`
+	const styleColor = bundleTitleColor ? bundleTitleColor : getCategoryColor(label);
+
+	const style = `-webkit-mask: url(${bundleImage}) 0 0/100% 100%; background-color: ${styleColor};`
 
 	const bundleWrapper = htmlToElements(`
 			<div class="zA yO" bundleLabel="${label}">
@@ -805,14 +819,15 @@ const handleHashChange = () => {
 };
 
 
-const LABEL_CONTAINER_SELECTOR = ".wT .n3 .zw .TK"
+const LABEL_CONTAINER_SELECTOR = ".aAw.FgKVne ~ .yJ"
 const watchLabelColorChanges = () => {
 	const labelBaseNode = document.querySelector(LABEL_CONTAINER_SELECTOR)
 	const observer = new MutationObserver(fixLabelColors)
 	function fixLabelColors() {
 		observer.disconnect();
 		[...document.querySelectorAll('.qj.aEe')].forEach(el => {
-			(el.setAttribute('style', el.getAttribute('style').replace(/(background-color:.*(?<!\!important));/g, '$1 !important;')))
+			let elStyle = el.getAttribute('style');
+			if (elStyle) (el.setAttribute('style', elStyle.replace(/(background-color:.*(?<!\!important));/g, '$1 !important;')))
 		})
 		observer.observe(labelBaseNode, { attributes: true, childList: true, subtree: true })
 	}

--- a/src/script.js
+++ b/src/script.js
@@ -804,11 +804,20 @@ const handleHashChange = () => {
   titleNode.href = hash;
 };
 
-const fixLabelColors = () => {
-	[...document.querySelectorAll('.qj.aEe')].forEach(el => {
-		(el.setAttribute('style', el.getAttribute('style').replace(/(background-color:.*(?<!\!important));/g, '$1 !important;')))
-	})
+
+const watchLabelColorChanges = () => {
+	const labelBaseNode = document.querySelector("[aria-labelledby=':6s']")
+	const observer = new MutationObserver(fixLabelColors)
+	function fixLabelColors() {
+		observer.disconnect();
+		[...document.querySelectorAll('.qj.aEe')].forEach(el => {
+			(el.setAttribute('style', el.getAttribute('style').replace(/(background-color:.*(?<!\!important));/g, '$1 !important;')))
+		})
+		observer.observe(labelBaseNode, { attributes: true, childList: true, subtree: true })
+	}
+	fixLabelColors()
 }
+
 
 window.addEventListener('hashchange', handleHashChange);
 
@@ -840,8 +849,7 @@ document.addEventListener('DOMContentLoaded', function () {
   waitForElement('a[title="Gmail"]', handleHashChange);
   waitForElement('a[title="Gmail"]', addFloatingComposeButton);
 
-  
-  waitForElement('div[aria-label="Side panel"] .bse-bvF-I.aT5-aOt-I[aria-label^="Get "]', ()=>window.setTimeout(fixLabelColors,2000));
+  waitForElement("[aria-labelledby=':6s']", watchLabelColorChanges);
 
   setInterval(updateReminders, 250);
 

--- a/src/script.js
+++ b/src/script.js
@@ -85,7 +85,8 @@ Element.prototype.remove = function () {
 };
 
 const getMyEmailAddress = () => {
-    let emailAddress = select.emailAddress().getAttribute('aria-label');
+	let emailAddr = select.emailAddress()
+    let emailAddress = emailAddr && emailAddr.getAttribute('aria-label');
     let emailAddressText = emailAddress && emailAddress.match(/.*?\((.*?)\)/)[1]
     return emailAddressText || "";
 }
@@ -354,20 +355,12 @@ const buildBundleWrapper = function (email, label, hasImportantMarkers) {
 	const bundleImage = getBundleImageForLabel(label);
 	const bundleTitleColor = bundleImage.match(/custom-cluster/) && getBundleTitleColorForLabel(email, label);
 
-// element {
-// 	mask: url(moz-extension://84c0ec10-195b-49d7-9583-7494886f16dd/images/ic_custom-cluster_24px_g60_r3_2x.png) 0 0/100% 100%;
-// 	background-color: rgb(101,62,155);
-// 	display: inline-block;
-// 	width: 28px;
-// 	height: 28px;
-// }	
-// 
-// [...document.querySelectorAll('.qj.aEe')].forEach(el=>console.log(el.setAttribute('style', el.getAttribute('style').replace(';',' !important;'))))
+	const style = `-webkit-mask: url(${bundleImage}) 0 0/100% 100%; background-color: ${bundleTitleColor};`
 
 	const bundleWrapper = htmlToElements(`
 			<div class="zA yO" bundleLabel="${label}">
-				<span class="oZ-x3 xY aid bundle-image">
-					<img src="${bundleImage}" ${bundleTitleColor ? `style="filter: drop-shadow(0 0 0 ${bundleTitleColor}) saturate(300%)"` : ''}/>
+				<span class="oZ-x3 xY aid bundle-image" style="${style}">
+					<!--<img src="${bundleImage}" ${bundleTitleColor ? `style="filter: drop-shadow(0 0 0 ${bundleTitleColor}) saturate(300%)"` : ''}/>-->
 				</span>
 				<span class="WA xY ${importantMarkerClass}"></span>
 				<span class="yX xY label-link .yW" ${bundleTitleColor ? `style="color: ${bundleTitleColor}"` : ''}>${label}</span>
@@ -811,6 +804,12 @@ const handleHashChange = () => {
   titleNode.href = hash;
 };
 
+const fixLabelColors = () => {
+	[...document.querySelectorAll('.qj.aEe')].forEach(el => {
+		(el.setAttribute('style', el.getAttribute('style').replace(/(background-color:.*(?<!\!important));/g, '$1 !important;')))
+	})
+}
+
 window.addEventListener('hashchange', handleHashChange);
 
 document.addEventListener('DOMContentLoaded', function () {
@@ -840,6 +839,9 @@ document.addEventListener('DOMContentLoaded', function () {
 
   waitForElement('a[title="Gmail"]', handleHashChange);
   waitForElement('a[title="Gmail"]', addFloatingComposeButton);
+
+  
+  waitForElement('div[aria-label="Side panel"] .bse-bvF-I.aT5-aOt-I[aria-label^="Get "]', ()=>window.setTimeout(fixLabelColors,2000));
 
   setInterval(updateReminders, 250);
 

--- a/src/script.js
+++ b/src/script.js
@@ -805,8 +805,9 @@ const handleHashChange = () => {
 };
 
 
+const LABEL_CONTAINER_SELECTOR = ".wT .n3 .zw .TK"
 const watchLabelColorChanges = () => {
-	const labelBaseNode = document.querySelector("[aria-labelledby=':6s']")
+	const labelBaseNode = document.querySelector(LABEL_CONTAINER_SELECTOR)
 	const observer = new MutationObserver(fixLabelColors)
 	function fixLabelColors() {
 		observer.disconnect();
@@ -817,7 +818,6 @@ const watchLabelColorChanges = () => {
 	}
 	fixLabelColors()
 }
-
 
 window.addEventListener('hashchange', handleHashChange);
 
@@ -849,7 +849,7 @@ document.addEventListener('DOMContentLoaded', function () {
   waitForElement('a[title="Gmail"]', handleHashChange);
   waitForElement('a[title="Gmail"]', addFloatingComposeButton);
 
-  waitForElement("[aria-labelledby=':6s']", watchLabelColorChanges);
+  waitForElement(LABEL_CONTAINER_SELECTOR, watchLabelColorChanges);
 
   setInterval(updateReminders, 250);
 

--- a/src/script.js
+++ b/src/script.js
@@ -354,6 +354,16 @@ const buildBundleWrapper = function (email, label, hasImportantMarkers) {
 	const bundleImage = getBundleImageForLabel(label);
 	const bundleTitleColor = bundleImage.match(/custom-cluster/) && getBundleTitleColorForLabel(email, label);
 
+// element {
+// 	mask: url(moz-extension://84c0ec10-195b-49d7-9583-7494886f16dd/images/ic_custom-cluster_24px_g60_r3_2x.png) 0 0/100% 100%;
+// 	background-color: rgb(101,62,155);
+// 	display: inline-block;
+// 	width: 28px;
+// 	height: 28px;
+// }	
+// 
+// [...document.querySelectorAll('.qj.aEe')].forEach(el=>console.log(el.setAttribute('style', el.getAttribute('style').replace(';',' !important;'))))
+
 	const bundleWrapper = htmlToElements(`
 			<div class="zA yO" bundleLabel="${label}">
 				<span class="oZ-x3 xY aid bundle-image">

--- a/src/style.css
+++ b/src/style.css
@@ -1478,7 +1478,8 @@ div[aria-label="Hangouts"][role="complementary"] {
  	width: 28px;
  	height: 28px !important;
  	vertical-align:middle;
- 	margin-top:-3px;
+ 	margin-top:-4px;
+ 	margin-bottom:-4px;
 }
 .bundle-image img {
 	width: 28px;

--- a/src/style.css
+++ b/src/style.css
@@ -1478,7 +1478,7 @@ div[aria-label="Hangouts"][role="complementary"] {
  	width: 28px;
  	height: 28px !important;
  	vertical-align:middle;
- 	margin-top:-4px;
+ 	margin-top:-3px;
 }
 .bundle-image img {
 	width: 28px;

--- a/src/style.css
+++ b/src/style.css
@@ -1474,6 +1474,11 @@ div[aria-label="Hangouts"][role="complementary"] {
 
 .bundle-image {
 	margin-left: 13px;
+ 	display: inline-block;
+ 	width: 28px;
+ 	height: 28px !important;
+ 	vertical-align:middle;
+ 	margin-top:-4px;
 }
 .bundle-image img {
 	width: 28px;


### PR DESCRIPTION
Label colours should now be working, as should bundle icon colours (on Firefox - which I don't think ever worked).

I also fixed an error coming from `getMyEmailAddress`