### PR TITLE
Changes for newly re-published Firefox version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ https://chrome.google.com/webstore/detail/inbox-reborn-theme-for-gm/bkphmihkdbdg
 
 ### Firefox
 
-1. Download [this repo's source code here](https://github.com/team-inbox/inbox-reborn/archive/master.zip), and unzip it where you like
-2. Create a new zip file of the main folder's content, so that there is no containing 'inbox-reborn-master' folder
-3. Make sure the Firefox setting `xpinstall.signatures.required` is set to `false` - this is done in `about:config`
-4. On the Firefox addons page, use the "Install Add-on From File..." on the gear menu to install the addon from the zip file you just created
+The extension is updated to version 0.5.9.27. It can be added via this link:
+
+https://addons.mozilla.org/en-GB/firefox/addon/inbox-reborn-theme-gmail/
+
 
 
 ## Features

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
   "homepage_url": "https://github.com/team-inbox/inbox-reborn",
   "browser_specific_settings": {
     "gecko": {
-      "id": "inbox-reborn@team-inbox.github.io"
+      "id": "inbox-reborn-new@team-inbox.github.io"
     }
   },
   "browser_action": {


### PR DESCRIPTION
Add-on was approved and is live at:

https://addons.mozilla.org/en-GB/firefox/addon/inbox-reborn-theme-gmail/

These changes update the ReadMe and make a small change to the manifest to alter the Gecko ID so it does not clash with Bouke's existing version on AMO