### PR TITLE
Adds Priority Inbox Headings option + fixes avatars within bundles

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Inbox Reborn theme for Gmail™",
-  "version": "0.5.9.28",
+  "version": "0.5.9.29",
   "manifest_version": 2,
   "description": "Adds features like reminders, email bundling and Inbox's minimalistic style to Gmail™",
   "homepage_url": "https://github.com/team-inbox/inbox-reborn",

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -41,7 +41,7 @@
             Provides cleaner inbox UI if "Priority Inbox" type enabled via settings<br /><br />
             <input type="radio" name="priority-inbox" value="enabled" id="priority-inbox-on"><label for="priority-inbox-on">Enabled</label>
             <br />
-            <input type="radio" name="priority-inbox" value="disabled" id="priority-inbox-off"><label for="priority-inbox-off">Disabled</label>
+            <input type="radio" name="priority-inbox" value="disabled" id="priority-inbox-off" checked="checked"><label for="priority-inbox-off">Disabled</label>
         </div>
     </div>
 </div>

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -35,6 +35,15 @@
             <input type="radio" name="avatar" value="disabled" id="avatar-off"><label for="avatar-off">Disabled</label>
         </div>
     </div>
+    <div class="setting">
+        <div class="setting-title">Hide Priority Inbox Headings</div>
+        <div class="setting-content">
+            Provides cleaner inbox UI if "Priority Inbox" type enabled via settings<br /><br />
+            <input type="radio" name="priority-inbox" value="enabled" id="priority-inbox-on"><label for="priority-inbox-on">Enabled</label>
+            <br />
+            <input type="radio" name="priority-inbox" value="disabled" id="priority-inbox-off"><label for="priority-inbox-off">Disabled</label>
+        </div>
+    </div>
 </div>
 <script src="script.js"></script>
 </body>

--- a/src/options/script.js
+++ b/src/options/script.js
@@ -1,15 +1,17 @@
 const REMINDER_TREATMENT_SELECTOR = 'input[name=reminder-treatment]';
 const BUNDLED_EMAIL_SELECTOR = 'input[name=email-bundling]';
-const AVATAR_SELECTOR = 'input[name=avatar]';
 const BUNDLE_ONE_SELECTOR = 'input[name=bundle-one]';
+const AVATAR_SELECTOR = 'input[name=avatar]';
+const PRIORITY_INBOX_SELECTOR = 'input[name=priority-inbox]';
 
 function saveOptions() {
 	const reminderTreatment = getSelectedRadioValue(REMINDER_TREATMENT_SELECTOR);
 	const emailBundling = getSelectedRadioValue(BUNDLED_EMAIL_SELECTOR);
-	const showAvatar = getSelectedRadioValue(AVATAR_SELECTOR);
 	const bundleOne = getCheckboxState(BUNDLE_ONE_SELECTOR);
+	const showAvatar = getSelectedRadioValue(AVATAR_SELECTOR);
+	const priorityInbox = getSelectedRadioValue(PRIORITY_INBOX_SELECTOR);
 
-	const options = { reminderTreatment, emailBundling, showAvatar, bundleOne };
+	const options = { reminderTreatment, emailBundling, bundleOne, showAvatar, priorityInbox };
 
 	localStorage.setItem('options', JSON.stringify(options));
 }
@@ -18,8 +20,10 @@ function restoreOptions() {
 	chrome.runtime.sendMessage({ method: 'getOptions' }, function(options) {
 		selectRadioWithValue(REMINDER_TREATMENT_SELECTOR, options.reminderTreatment);
 		selectRadioWithValue(BUNDLED_EMAIL_SELECTOR, options.emailBundling);
-		selectRadioWithValue(AVATAR_SELECTOR, options.showAvatar);
 		setCheckbox(BUNDLE_ONE_SELECTOR, options.bundleOne);
+		selectRadioWithValue(AVATAR_SELECTOR, options.showAvatar);
+		selectRadioWithValue(PRIORITY_INBOX_SELECTOR, options.priorityInbox);
+		
 	});
 }
 
@@ -41,5 +45,6 @@ const monitorChange = element => element.addEventListener('click', saveOptions);
 document.addEventListener('DOMContentLoaded', restoreOptions);
 document.querySelectorAll(REMINDER_TREATMENT_SELECTOR).forEach(monitorChange);
 document.querySelectorAll(BUNDLED_EMAIL_SELECTOR).forEach(monitorChange);
-document.querySelectorAll(AVATAR_SELECTOR).forEach(monitorChange);
 monitorChange(document.querySelector(BUNDLE_ONE_SELECTOR));
+document.querySelectorAll(AVATAR_SELECTOR).forEach(monitorChange);
+document.querySelectorAll(PRIORITY_INBOX_SELECTOR).forEach(monitorChange);

--- a/src/script.js
+++ b/src/script.js
@@ -29,10 +29,10 @@ const STYLE_NODE_ID_PREFIX = 'hide-email-';
 let select = {
     emailAddress:        ()=>document.querySelector("a[aria-label^='Google Account:']"),
     tabs:                ()=>document.querySelectorAll('.aKz'),
-    bundleWrappers:      ()=>document.querySelectorAll('.BltHke[role=main] .bundle-wrapper'),
+    bundleWrappers:      ()=>document.querySelectorAll('.oy8Mbf[role=main] .bundle-wrapper'),
     inbox:               ()=>document.querySelector('.nZ[data-tooltip=Inbox]'),
     importanceMarkers:   ()=>document.querySelector('td.WA.xY'),
-    emails:              ()=>document.querySelectorAll('.BltHke[role=main] .zA'),
+    emails:              ()=>document.querySelectorAll('.oy8Mbf[role=main] .zA'),
     currentTab:          ()=>document.querySelector('.aAy[aria-selected="true"]'),
     menu:                ()=>document.body.querySelector('.J-Ke.n4.ah9'),
     composeButtonNew:    ()=>document.querySelector('.Yh.akV'),

--- a/src/script.js
+++ b/src/script.js
@@ -30,7 +30,7 @@ const PRIORITY_INBOX_OPTION_CLASS = 'priority-inbox-enabled';
 let select = {
     emailAddress:        ()=>document.querySelector("a[aria-label^='Google Account:']"),
     tabs:                ()=>document.querySelectorAll('.aKz'),
-    bundleWrappers:      ()=>document.querySelectorAll('.BltHke[role=main] .bundle-wrapper, .aE3[role=main] .bundle-wrapper, .oy8Mbf[role=main] .bundle-wrapper'),
+    bundleWrappers:      ()=>document.querySelectorAll('.oy8Mbf[role=main] .bundle-wrapper'),
     inbox:               ()=>document.querySelector('.nZ[data-tooltip=Inbox]'),
     importanceMarkers:   ()=>document.querySelector('td.WA.xY'),
     emails:              ()=>document.querySelectorAll('.oy8Mbf[role=main] .zA, .oy8Mbf[style]:not([role=navigation]) .zA'),

--- a/src/script.js
+++ b/src/script.js
@@ -33,7 +33,7 @@ let select = {
     bundleWrappers:      ()=>document.querySelectorAll('.BltHke[role=main] .bundle-wrapper, .aE3[role=main] .bundle-wrapper, .oy8Mbf[role=main] .bundle-wrapper'),
     inbox:               ()=>document.querySelector('.nZ[data-tooltip=Inbox]'),
     importanceMarkers:   ()=>document.querySelector('td.WA.xY'),
-    emails:              ()=>document.querySelectorAll('.oy8Mbf[role=main] .zA'),
+    emails:              ()=>document.querySelectorAll('.oy8Mbf[role=main] .zA, .oy8Mbf[style]:not([role=navigation]) .zA'),
     currentTab:          ()=>document.querySelector('.aAy[aria-selected="true"]'),
     menu:                ()=>document.body.querySelector('.J-Ke.n4.ah9'),
     composeButtonNew:    ()=>document.querySelector('.Yh.akV'),

--- a/src/script.js
+++ b/src/script.js
@@ -17,6 +17,7 @@ const AVATAR_EMAIL_CLASS = 'email-with-avatar';
 const AVATAR_CLASS = 'avatar';
 const AVATAR_OPTION_CLASS = 'show-avatar-enabled';
 const STYLE_NODE_ID_PREFIX = 'hide-email-';
+const PRIORITY_INBOX_OPTION_CLASS = 'priority-inbox-enabled';
 
 //
 // Element Selectors
@@ -32,7 +33,7 @@ let select = {
     bundleWrappers:      ()=>document.querySelectorAll('.BltHke[role=main] .bundle-wrapper, .aE3[role=main] .bundle-wrapper, .oy8Mbf[role=main] .bundle-wrapper'),
     inbox:               ()=>document.querySelector('.nZ[data-tooltip=Inbox]'),
     importanceMarkers:   ()=>document.querySelector('td.WA.xY'),
-    emails:              ()=>document.querySelectorAll('.BltHke[role=main] .zA, .aE3[role=main] .zA, .oy8Mbf[role=main] .zA'),
+    emails:              ()=>document.querySelectorAll('.oy8Mbf[role=main] .zA'),
     currentTab:          ()=>document.querySelector('.aAy[aria-selected="true"]'),
     menu:                ()=>document.body.querySelector('.J-Ke.n4.ah9'),
     composeButtonNew:    ()=>document.querySelector('.Yh.akV'),
@@ -256,6 +257,12 @@ const reloadOptions = () => {
 		document.querySelectorAll('.' + AVATAR_EMAIL_CLASS).forEach(avatarEl => avatarEl.classList.remove(AVATAR_EMAIL_CLASS));
 		// Remove avatar elements
 		document.querySelectorAll('.' + AVATAR_CLASS).forEach(avatarEl => avatarEl.remove());
+	}
+	// Add option classes to body for css styling, removes priority inbox section headings when enabled
+	if (options.priorityInbox == 'enabled' && !document.body.classList.contains(PRIORITY_INBOX_OPTION_CLASS)) {
+		document.body.classList.add(PRIORITY_INBOX_OPTION_CLASS);
+	} else if (options.hidePriorityInboxHeadings == 'disabled' && document.body.classList.contains(PRIORITY_INBOX_OPTION_CLASS)) {
+		document.body.classList.remove(PRIORITY_INBOX_OPTION_CLASS);
 	}
 
 	// Add option classes to body for css styling, and unbundle emails when disabled

--- a/src/style.css
+++ b/src/style.css
@@ -85,9 +85,14 @@ header {
 }
 .D.E.G-atb {
     width: var(--email-max-width);
-    /* this percent effectively enforces a 3.5% (7% / 2) padding when */
-    max-width: 93%;
 }
+
+/* Add box-shadow to open email + match toolbar width */
+.nH.a98.iY {
+	margin: 2px 16px 0;
+	box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0,0,0,.12), 0 2px 4px rgba(0,0,0,.24) !important
+}
+
 /* .PY applied when bundle/email open */
 .D.E.G-atb.PY {
 	height: auto;

--- a/src/style.css
+++ b/src/style.css
@@ -1183,8 +1183,20 @@ header form input {
 /* Inbox and top toolbar layout	    						 */
 /* --------------------------------------------- */
 
+/* Hides pale blue on bottom of main panel */
 .Tm {
 	padding-bottom: 16px !important;
+}
+
+/* Hides pale blue on bottom for side panel */
+.aUx {
+	min-height: calc(100vh - 64px);	
+}
+
+/* Fixes box-shadow getting cutoff by parent */
+.Nu {
+	padding-bottom: 6px;
+	height: auto !important;
 }
 
 /* Search results "Some messages in Trash or Spam match your search" area */

--- a/src/style.css
+++ b/src/style.css
@@ -1195,6 +1195,7 @@ header form input {
 
 /* Fixes box-shadow getting cutoff by parent */
 .Nu {
+	padding-top: 2px;
 	padding-bottom: 6px;
 	height: auto !important;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -781,10 +781,6 @@ button.gb_ff.gb_gf  {
 	border-radius: 0 !important;
 }
 
-.Cp {
-	margin-top: 2px !important;
-}
-
 /*
 **
 **END OF MAIN MENU, SEARCH BAR AND EMAIL AREA
@@ -1190,10 +1186,12 @@ header form input {
 .Tm {
 	padding-bottom: 16px !important;
 }
-/* table of emails in list view */
-.F {
-	padding-bottom: 16px !important;
+
+/* Search results "Some messages in Trash or Spam match your search" area */
+.TD {
+	background: transparent !important;
 }
+
 /* Right sidebar set height override */
 .nH.bAw.nn {
 	height: calc(100vh - 64px) !important;
@@ -1281,11 +1279,6 @@ header form input {
 /* the bar that the menu items typically rest on */
 .G-atb {
 	padding-bottom: 12px !important;
-}
-
-/* shifts the inbox down */
-.aeF {
-	margin-top: -8px;
 }
 
 .nH.aqK {

--- a/src/style.css
+++ b/src/style.css
@@ -106,8 +106,13 @@ header {
 	background: #f2f2f2;
 }
 
+/* Match right margin to center main content if left sidebar collapsed */
 .aBA + .bkK > .nH > .ar4 > div {
 	margin-left: var(--inbox-margin-right);
+}
+/* Match light gray BG to hide pale blue while animating sidebar open or close */
+.nH.aqk.aql.bkL {
+	background: #f2f2f2;
 }
 
 /* Attachment icon */

--- a/src/style.css
+++ b/src/style.css
@@ -1382,8 +1382,8 @@ header form input {
 	height: 22px !important;
 	border-radius: 2px !important;
 }
-/* Hides inline "Inbox" label on emails */
-.ar:first-of-type {
+/* Hides inline "Inbox" label on emails within bundles */
+.nH .AO .aeF .bv9 .ar:first-of-type {
 	display: none;
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -1382,6 +1382,10 @@ header form input {
 	height: 22px !important;
 	border-radius: 2px !important;
 }
+/* Hides inline "Inbox" label on emails */
+.ar:first-of-type {
+	display: none;
+}
 
 .ar .av {
 	padding-top: 2px;

--- a/src/style.css
+++ b/src/style.css
@@ -83,8 +83,10 @@ header {
 .aeH > .D.E.G-atb {
 	margin: auto !important;
 	max-width: none;
+	width: 100%;
 }
 .D.E.G-atb {
+	margin: 0 auto 16px auto !important;
     width: var(--email-max-width);
     /* this percent effectively enforces a 3.5% (7% / 2) padding when */
     max-width: 97%;

--- a/src/style.css
+++ b/src/style.css
@@ -1383,11 +1383,6 @@ header form input {
 	border-radius: 2px !important;
 }
 
-/* Hide inline labels within bundle email lists */
-.nH .AO .aeF .bv9 .ar {
-	display: none;
-}
-
 .ar .av {
 	padding-top: 2px;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -86,7 +86,7 @@ header {
 	width: 100%;
 }
 .D.E.G-atb {
-	margin: 0 auto 16px auto !important;
+	margin: 0 auto !important;
     width: var(--email-max-width);
     /* this percent effectively enforces a 3.5% (7% / 2) padding when */
     max-width: 97%;

--- a/src/style.css
+++ b/src/style.css
@@ -80,22 +80,24 @@ header {
 }
 
 /* Align toolbar with email width */
-.aeH > .G-atb {
+.aeH > .D.E.G-atb {
 	margin: auto !important;
+	max-width: none;
 }
 .D.E.G-atb {
     width: var(--email-max-width);
+    /* this percent effectively enforces a 3.5% (7% / 2) padding when */
+    max-width: 97%;
+}
+/* .PY applied when bundle/email open */
+.D.E.G-atb.PY {
+	height: auto;
 }
 
 /* Add box-shadow to open email + match toolbar width */
 .nH.a98.iY {
 	margin: 2px 16px 0;
 	box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0,0,0,.12), 0 2px 4px rgba(0,0,0,.24) !important
-}
-
-/* .PY applied when bundle/email open */
-.D.E.G-atb.PY {
-	height: auto;
 }
 
 .aeH {

--- a/src/style.css
+++ b/src/style.css
@@ -856,6 +856,14 @@ button.gb_ff.gb_gf  {
 .w-asV.bbg.aiw[pageTitle="archive"] {
 	background-color: #0f9d58;
 }
+.w-asV.bbg.aiw[pageTitle="chat"],
+.w-asV.bbg.aiw[pageTitle="onboarding"] {
+	background-color: #00AC47; /* #0F9D58 is Google brand color green, but not as vibrant */
+}
+
+.w-asV.bbg.aiw[pageTitle="calls"] {
+	background-color: #DB4437;
+}
 
 /* Fix background color for vertical split layout */
 .UI .nH.nn,
@@ -915,11 +923,13 @@ a[title="Gmail"][href="#drafts"]::after {
 a[title="Gmail"][href="#imp"]::after {
 	content: 'Important';
 }
-a[title="Gmail"][href="#chat"]::after {
+a[title="Gmail"][href="#chat"]::after,
+a[title="Gmail"][href="#onboarding"]::after,
+a[title="Gmail"][href="#browse"]::after {
 	content: 'Chat';
 }
-a[title="Gmail"][href="#rooms"]::after {
-	content: 'Spaces';
+a[title="Gmail"][href="#calls"]::after {
+	content: 'Meet';
 }
 a[title="Gmail"][href="#scheduled"]::after {
 	content: 'Scheduled';

--- a/src/style.css
+++ b/src/style.css
@@ -1211,13 +1211,8 @@ header form input {
 	margin: 0 5px;
 }
 
-/* Inbox: hide the starred heading */
-.nH.Wg.aAD.aAr {
-	display: none;
-}
-
-/* Inbox: hide the everything else heading */
-.nH.Wg.aAr {
+/* Inbox: hide "Priority Inbox" section headings */
+.priority-inbox-enabled .nH .Wg.aAr {
 	display: none;
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -106,6 +106,10 @@ header {
 	background: #f2f2f2;
 }
 
+.aBA + .bkK > .nH > .ar4 > div {
+	margin-left: var(--inbox-margin-right);
+}
+
 /* Attachment icon */
 .yE {
 	display: none !important;

--- a/src/style.css
+++ b/src/style.css
@@ -1370,6 +1370,11 @@ header form input {
 	border-radius: 2px !important;
 }
 
+/* Hide inline labels within bundle email lists */
+.nH .AO .aeF .bv9 .ar {
+	display: none;
+}
+
 .ar .av {
 	padding-top: 2px;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -78,6 +78,12 @@ header {
 	max-width: 1180px;
 	padding: 0 10px;
 }
+/* Center search toolbar */
+.biW {
+	margin-left: auto !important;
+	margin-right: auto !important;
+	max-width: var(--email-max-width);
+}
 
 /* Align toolbar with email width */
 .aeH > .D.E.G-atb {

--- a/src/style.css
+++ b/src/style.css
@@ -89,10 +89,6 @@ header {
     /* this percent effectively enforces a 3.5% (7% / 2) padding when */
     max-width: 97%;
 }
-/* .PY applied when bundle/email open */
-.D.E.G-atb.PY {
-	height: auto;
-}
 
 /* Add box-shadow to open email + match toolbar width */
 .nH.a98.iY {


### PR DESCRIPTION
- Adds "Hide Priority Inbox Headings" option to hide these headings on desktop for a cleaner experience, really only affects users who have the "Priority Inbox" option selected in Settings > Inbox > Inbox type (provides more focused browsing, especially in mobile app)
- Adds green header color for Chat views
- Adds red header color for Meet views
- Fixes #81 
- A little bit of general cleanup

Tested on latest versions of Firefox + Chrome