### PR TITLE
Fix for non-default bundle custom coloring options + floating buttons positioning when add ons panel is closed

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -41,7 +41,7 @@ let select = {
     composeButton:       ()=>select.composeButtonOld() || select.composeButtonNew(),
     menuParent:          ()=>document.querySelector('.wT .byl'),
     menuRefer:           ()=>document.querySelector('.wT .byl>.TK'),
-    titleNode:           ()=>document.querySelectorAll('a[title="Gmail"]')[1],
+    titleNode:           ()=>document.querySelectorAll('a[aria-label="Gmail"]')[1],
     headerElement:       ()=>document.querySelector('.w-asV.bbg.aiw'),
     messageBody:         ()=>document.querySelector('div[aria-label="Message Body"]'),
     messageFrom:         ()=>document.querySelector('input[name="from"]'),
@@ -868,8 +868,8 @@ document.addEventListener('DOMContentLoaded', function () {
 	});
   document.body.appendChild(addReminder);
 
-  waitForElement('a[title="Gmail"]', handleHashChange);
-  waitForElement('a[title="Gmail"]', addFloatingComposeButton);
+  waitForElement('a[aria-label="Gmail"]', handleHashChange);
+  waitForElement('a[aria-label="Gmail"]', addFloatingComposeButton);
 
   waitForElement(LABEL_CONTAINER_SELECTOR, watchLabelColorChanges);
 

--- a/src/script.js
+++ b/src/script.js
@@ -903,7 +903,7 @@ const moveFloatersRight = () => {
 const sidePanelHandler = () => {
 	const sidePanel = document.querySelector('div[aria-label="Side panel"]');
 	const sidePanelBtns = sidePanel.querySelectorAll('.bse-bvF-I.aT5-aOt-I:not(#qJTzr)'); // ignore the + btn
-	const addOnsFrame = document.querySelector('.bq9.buW');
+	const addOnsFrame = document.querySelector('.buW');
 
 	for(let b = 0; b < sidePanelBtns.length; b++) {
 
@@ -917,13 +917,15 @@ const sidePanelHandler = () => {
 	if(addOnsFrame) {
 		if(!addOnsFrame.classList.contains('br3')) {
 			moveFloatersLeft();
-			sidePanelMutationHandler();
+		} else {
+			moveFloatersRight();
 		}
+		sidePanelMutationHandler();
 	}
 }
 	
-const sidePanelMutationHandler = () => waitForElement('.bq9.buW', () => {
-	const addOnsPanel = document.querySelector('.bq9.buW');
+const sidePanelMutationHandler = () => waitForElement('.buW', () => {
+	const addOnsPanel = document.querySelector('.buW');
 	const panelResized = new ResizeObserver((entries) => {
 		for (let entry of entries) {	
 			if (entry.contentRect.width == 0) {

--- a/src/style.css
+++ b/src/style.css
@@ -899,22 +899,22 @@ button.gb_ff.gb_gf  {
 }
 
 /* Gmail icon (old, new) */
-a[title="Gmail"] {
+a[aria-label="Gmail"] {
 	width: 120px;
 	overflow: hidden;
 	text-decoration: none;
 }
-a[title="Gmail"] img {
+a[aria-label="Gmail"] img {
 	display: none;
 }
 
 /* Fix for padding applied to a[href="#inbox"] */
-a[title="Gmail"][href="#inbox"] {
+a[aria-label="Gmail"][href="#inbox"] {
 	padding-left: 0;
 }
 
 /* Gmail text */
-a[title="Gmail"]::after {
+a[aria-label="Gmail"]::after {
 	content: 'Search';
 	font-size: 20px;
 	color: #FFF;
@@ -923,45 +923,45 @@ a[title="Gmail"]::after {
 	padding-left: 7px;
 }
 
-a[title="Gmail"][href="#inbox"]::after, a[title="Gmail"][href="#settings"]::after {
+a[aria-label="Gmail"][href="#inbox"]::after, a[aria-label="Gmail"][href="#settings"]::after {
 	content: 'Inbox';
 }
-a[title="Gmail"][href="#snoozed"]::after {
+a[aria-label="Gmail"][href="#snoozed"]::after {
 	content: 'Snoozed';
 }
-a[title="Gmail"][href="#archive"]::after {
+a[aria-label="Gmail"][href="#archive"]::after {
 	content: 'Done';
 }
-a[title="Gmail"][href="#starred"]::after {
+a[aria-label="Gmail"][href="#starred"]::after {
 	content: 'Starred';
 }
-a[title="Gmail"][href="#sent"]::after {
+a[aria-label="Gmail"][href="#sent"]::after {
 	content: 'Sent';
 }
-a[title="Gmail"][href="#drafts"]::after {
+a[aria-label="Gmail"][href="#drafts"]::after {
 	content: 'Drafts';
 }
-a[title="Gmail"][href="#imp"]::after {
+a[aria-label="Gmail"][href="#imp"]::after {
 	content: 'Important';
 }
-a[title="Gmail"][href="#chat"]::after,
-a[title="Gmail"][href="#onboarding"]::after,
-a[title="Gmail"][href="#browse"]::after {
+a[aria-label="Gmail"][href="#chat"]::after,
+a[aria-label="Gmail"][href="#onboarding"]::after,
+a[aria-label="Gmail"][href="#browse"]::after {
 	content: 'Chat';
 }
-a[title="Gmail"][href="#calls"]::after {
+a[aria-label="Gmail"][href="#calls"]::after {
 	content: 'Meet';
 }
-a[title="Gmail"][href="#scheduled"]::after {
+a[aria-label="Gmail"][href="#scheduled"]::after {
 	content: 'Scheduled';
 }
-a[title="Gmail"][href="#all"]::after {
+a[aria-label="Gmail"][href="#all"]::after {
 	content: 'All Mail';
 }
-a[title="Gmail"][href="#spam"]::after {
+a[aria-label="Gmail"][href="#spam"]::after {
 	content: 'Spam';
 }
-a[title="Gmail"][href="#trash"]::after {
+a[aria-label="Gmail"][href="#trash"]::after {
 	content: 'Trash';
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -1563,7 +1563,6 @@ div[aria-label="Hangouts"][role="complementary"] {
 	margin-left: 5px;
 	font-size: 13px;
 	margin-right: 32px;
-	color: #404040 !important;
 }
 /* allows user-specified custom color labels/bundles */
 .bundle-wrapper .label-link[style="color: rgb(225, 227, 225)"] {
@@ -1624,7 +1623,6 @@ div[aria-label="Hangouts"][role="complementary"] {
 /* Bundle row settings */
 .zA > span.oZ-x3 {
 	order: 0;
-	background-color: #444 !important;
 }
 
 /* allows user-specified custom color labels/bundles */

--- a/src/style.css
+++ b/src/style.css
@@ -1563,6 +1563,9 @@ div[aria-label="Hangouts"][role="complementary"] {
 	margin-left: 5px;
 	font-size: 13px;
 	margin-right: 32px;
+}
+/* allows user-specified custom color labels/bundles */
+.bundle-wrapper .label-link[style="color: rgb(225, 227, 225)"] {
 	color: #404040 !important;
 }
 .bundle-wrapper.contains-unread .label-link,
@@ -1620,6 +1623,10 @@ div[aria-label="Hangouts"][role="complementary"] {
 /* Bundle row settings */
 .zA > span.oZ-x3 {
 	order: 0;
+}
+
+/* allows user-specified custom color labels/bundles */
+.zA > .xY.bundle-image[style*="background-color: rgb(225, 227, 225)"] {
 	background-color: #444 !important;
 }
 
@@ -1644,7 +1651,6 @@ div[aria-label="Hangouts"][role="complementary"] {
 	background-color: rgb(219, 68, 55) !important;
 }
 
-.zA[bundlelabel="Travel"] > span.oZ-x3,
 .zA[bundlelabel="Travel"] > span.oZ-x3 {
 	background-color: rgb(156, 39, 176) !important;
 }
@@ -1652,7 +1658,6 @@ div[aria-label="Hangouts"][role="complementary"] {
 .zA[bundlelabel="Updates"] > span.oZ-x3 {
 	background-color: rgb(255, 104, 57) !important;
 }
-
 
 .hide-important-markers {
 	display: none !important;

--- a/src/style.css
+++ b/src/style.css
@@ -1651,12 +1651,12 @@ body.email-bundling-enabled.bundle-page .nH.ar4.B .yi {
 }
 
 .add-reminder.moved {
-	right: 348px;
+	right: 388px;
 }
 
 .floating-compose.moved,
 .Yh.akV.moved {
-	right: 340px;
+	right: 380px;
 }
 
 /* Hide inbox count when Mail collapsed in left side bar */

--- a/src/style.css
+++ b/src/style.css
@@ -977,18 +977,35 @@ header svg {
 }
 
 /* Top bar Google Chat status selector */
-.Yb {
-	background-color: transparent !important;
+.lJradf.X72uL { /* bg */
+	background: rgba(255, 255, 255, 0.125) !important;
 }
-.Yb, .Yb:not(.abs):focus {
-	border-color: transparent !important;
+
+.lJradf.X72uL:not(.Dnplmc):hover {
+	background: rgba(60, 64, 67, 0.08) !important;
 }
-.Yb[aria-label="Status: Active"] .Yg { /* (Active) Icon */
-	background-color: #34d058 !important;
-}
-.Yc { /* Text */
+
+.C2Qm1d.X72uL { /* Text */
 	color: #FFF !important;
 }
+
+/* ? icon */
+
+.t6.zH[aria-expanded="true"]:hover, .t6.zH[aria-expanded="true"] {
+	background-color: rgba(95,99,104,0.24);
+}
+
+/* settings icon */
+
+.FH[aria-expanded="true"]:hover {
+	background-color: rgba(95,99,104,0.24);
+}
+
+/* gapps shorcut (expanded) icon */
+.gb_B[aria-expanded="true"] .gb_F {
+	fill: #fff !important;
+}
+
 
 /* Search bar (old, new) */
 header form {
@@ -1546,6 +1563,7 @@ div[aria-label="Hangouts"][role="complementary"] {
 	margin-left: 5px;
 	font-size: 13px;
 	margin-right: 32px;
+	color: #404040 !important;
 }
 .bundle-wrapper.contains-unread .label-link,
 .bundle-wrapper .bundle-senders span.strong {
@@ -1587,7 +1605,7 @@ div[aria-label="Hangouts"][role="complementary"] {
 .zA.yO[bundleLabel="Trips"] .label-link > span:not(.bundle-count) {
 	color: rgb(156, 39, 176);
 }
-.zA.yO[bundleLabel="Finance"] .label-link > span:not(.bundle-count) {
+.zA.yO[bundleLabel^="Finance"] .label-link > span:not(.bundle-count) {
 	color: rgb(103, 159, 56);
 }
 .zA.yO[bundleLabel="Orders"] .label-link > span:not(.bundle-count),
@@ -1602,7 +1620,39 @@ div[aria-label="Hangouts"][role="complementary"] {
 /* Bundle row settings */
 .zA > span.oZ-x3 {
 	order: 0;
+	background-color: #444 !important;
 }
+
+.zA[bundlelabel^="Finance"] > .xY.bundle-image {
+	background-color: rgb(103, 159, 56) !important;
+}
+
+.zA[bundlelabel="Forums"] > .xY.bundle-image {
+	background-color: rgb(63, 81, 181) !important;
+}
+
+.zA[bundlelabel="Orders"] > span.oZ-x3,
+.zA[bundlelabel="Purchases"] > span.oZ-x3 {
+	background-color: rgb(121, 85, 72) !important;
+}
+
+.zA[bundlelabel="Promotions"] > span.oZ-x3 {
+	background-color: rgb(0,188,212) !important;
+}
+
+.zA[bundlelabel="Social"] > span.oZ-x3 {
+	background-color: rgb(219, 68, 55) !important;
+}
+
+.zA[bundlelabel="Travel"] > span.oZ-x3,
+.zA[bundlelabel="Travel"] > span.oZ-x3 {
+	background-color: rgb(156, 39, 176) !important;
+}
+
+.zA[bundlelabel="Updates"] > span.oZ-x3 {
+	background-color: rgb(255, 104, 57) !important;
+}
+
 
 .hide-important-markers {
 	display: none !important;


### PR DESCRIPTION
I saw you cherry picked two of these commits in this morning before I made a proper PR, but there was another commit that should've been rolled in, as well as another issue that I did a sloppy job fixing and my latest (non merge related) commit here remedies it moar better.

Google has recently applied a very light gray color to any non-default labels/bundles that is difficult to read on top of the white background. My original fix just darkened them to match, but I realized that this would override any custom coloring options a user may have applied to their labels/bundles.

See below:
<img width="722" alt="Screen Shot 2025-07-05 at 12 16 46 PM" src="https://github.com/user-attachments/assets/fbdf7a98-f074-4134-acf3-a6876539ab8a" />
