### PR TITLE
unify Chrome + Firefox support in single repo

### DIFF
--- a/firefox.json
+++ b/firefox.json
@@ -2,6 +2,9 @@
   "name": "Inbox Reborn theme for Gmail™",
   "version": "1.0.1",
   "manifest_version": 2,
+  "permissions": [
+    "storage"
+  ],
   "description": "Adds features like reminders, email bundling, and Inbox's minimalistic style to Gmail™",
   "homepage_url": "https://github.com/team-inbox/inbox-reborn",
   "browser_specific_settings": {
@@ -14,8 +17,10 @@
   },
   "options_ui": {
     "page": "src/options/options.html",
-    "open_in_tab": false
+    "open_in_tab": false,
+    "browser_style": true
   },
+  "options_page": "src/options/options.html",
   "background": {
     "scripts": ["src/background.js"],
     "persistent": false

--- a/src/background.js
+++ b/src/background.js
@@ -1,6 +1,9 @@
-chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
+// Polyfill for cross-browser compatibility
+const browserAPI = (typeof browser !== 'undefined') ? browser : chrome;
+
+browserAPI.runtime.onMessage.addListener(function(request, sender, sendResponse) {
     if (request.method === 'getOptions') {
-        chrome.storage.local.get('options', function(result) {
+        browserAPI.storage.local.get('options', function(result) {
             const options = result.options || {};
             options.reminderTreatment = options.reminderTreatment || 'containing-word';
             options.emailBundling = options.emailBundling || 'enabled';

--- a/src/options/script.js
+++ b/src/options/script.js
@@ -1,3 +1,8 @@
+// Polyfill for cross-browser compatibility with callback support
+const browserAPI = (typeof chrome !== 'undefined' && chrome.runtime && typeof chrome.runtime.sendMessage === 'function')
+    ? chrome
+    : (typeof browser !== 'undefined' ? browser : chrome);
+
 const REMINDER_TREATMENT_SELECTOR = 'input[name=reminder-treatment]';
 const BUNDLED_EMAIL_SELECTOR = 'input[name=email-bundling]';
 const BUNDLE_ONE_SELECTOR = 'input[name=bundle-one]';
@@ -13,13 +18,13 @@ function saveOptions() {
 
 	const options = { reminderTreatment, emailBundling, bundleOne, showAvatar, priorityInbox };
 
-	chrome.storage.local.set({ 'options': options }, function() {
+	browserAPI.storage.local.set({ 'options': options }, function() {
     console.log('Options saved:', options);
 });
 }
 
 function restoreOptions() {
-	chrome.runtime.sendMessage({ method: 'getOptions' }, function(options) {
+	browserAPI.runtime.sendMessage({ method: 'getOptions' }, function(options) {
 		selectRadioWithValue(REMINDER_TREATMENT_SELECTOR, options.reminderTreatment);
 		selectRadioWithValue(BUNDLED_EMAIL_SELECTOR, options.emailBundling);
 		setCheckbox(BUNDLE_ONE_SELECTOR, options.bundleOne);


### PR DESCRIPTION
- Added cross-browser polyfill in options script to detect and use Chrome-style callbacks (chrome.runtime.sendMessage) or standard `browser` APIs as available
- Updated Firefox manifest (firefox.json) to include `"storage"` permission, `"browser_style": true` for Options UI, and legacy `"options_page"` fallback
- Removed trailing commas to ensure valid JSON and MV2 compliance
- Verified that both Chrome and Firefox load the same `src/options/options.html`
- Now shipped from one repo, this extension fully supports Chrome and Firefox