### PR TITLE
Lint/format tooling, CI workflow, dark mode overhaul, and store-zip slimming

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Prettier (formatting)
+        run: npm run format:check
+      - name: ESLint (JavaScript)
+        run: npm run lint:js
+      - name: stylelint (CSS)
+        run: npm run lint:css
+      - name: Validate manifests
+        run: |
+          node -e "JSON.parse(require('fs').readFileSync('chrome.json', 'utf8'))"
+          node -e "JSON.parse(require('fs').readFileSync('firefox.json', 'utf8'))"
+      - name: Check manifest versions match
+        run: |
+          node -e "
+            const fs = require('fs');
+            const chrome = JSON.parse(fs.readFileSync('chrome.json', 'utf8'));
+            const firefox = JSON.parse(fs.readFileSync('firefox.json', 'utf8'));
+            if (chrome.version !== firefox.version) {
+              console.error('Version mismatch: chrome.json=' + chrome.version + ' firefox.json=' + firefox.version);
+              process.exit(1);
+            }
+            console.log('Manifest versions match: ' + chrome.version);
+          "
+
+  build:
+    name: Build extension
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Build Chrome zip
+        run: BUILD_OUTPUT_DIR=dist node build.js chrome zip
+      - name: Build Firefox zip
+        run: BUILD_OUTPUT_DIR=dist node build.js firefox zip
+      - name: Upload extension zips
+        uses: actions/upload-artifact@v4
+        with:
+          name: extension-zips
+          path: dist/*.zip
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .idea/
 *.iml
 .DS_Store
+node_modules/
+dist/
+build/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,8 @@
+node_modules/
+dist/
+build/
+docs/
+images/
+icons/
+screenshots/
+package-lock.json

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "printWidth": 100
+}

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,19 @@
+{
+  "extends": "stylelint-config-standard",
+  "ignoreFiles": ["node_modules/**", "dist/**", "build/**", "docs/**"],
+  "rules": {
+    "no-descending-specificity": null,
+    "selector-class-pattern": null,
+    "selector-id-pattern": null,
+    "custom-property-pattern": null,
+    "property-no-vendor-prefix": null,
+    "selector-no-vendor-prefix": null,
+    "value-no-vendor-prefix": null,
+    "at-rule-no-vendor-prefix": null,
+    "media-feature-name-no-vendor-prefix": null,
+    "at-rule-prelude-no-invalid": null,
+    "no-duplicate-selectors": null,
+    "declaration-block-no-shorthand-property-overrides": null,
+    "declaration-block-no-redundant-longhand-properties": null
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Inbox Reborn theme for Gmail™
-#### *Formerly known as Inbox in Gmail*
+
+#### _Formerly known as Inbox in Gmail_
 
 Web extension which modifies Gmail™ to bring back the features and uncluttered design you knew and loved from Google's discontinued Inbox
 
@@ -10,7 +11,6 @@ Web extension which modifies Gmail™ to bring back the features and uncluttered
 ### Chrome & Microsoft Edge Install
 
 https://chrome.google.com/webstore/detail/inbox-reborn-theme-for-gm/bkphmihkdbdgedlaflnkhnmnmibffomf
-
 
 ### Firefox Install
 
@@ -25,7 +25,6 @@ https://addons.mozilla.org/en-GB/firefox/addon/inbox-reborn-theme-gmail/
 - Colored avatars based on the sender's name
 - Calendar events displayed on a small card, with inline responses
 
-
 ## Extension Options
 
 <img src="https://github.com/team-inbox/inbox-reborn/blob/master/screenshots/options.png?raw=true" alt="options popup screenshot" width="400">
@@ -33,19 +32,22 @@ https://addons.mozilla.org/en-GB/firefox/addon/inbox-reborn-theme-gmail/
 Click the extension's icon at the top right of your browser to adjust the behavior of some features:
 
 #### Dark Mode
+
 This option is used to enable dark mode on and off
 
 - Toggle Dark Mode On and then goto Settings/Theme -> Dark
-- Toggle Dark Mode Off and then goto Settings/Theme -> Default 
+- Toggle Dark Mode Off and then goto Settings/Theme -> Default
 
 #### Reminders
+
 This option is used to determine how to treat emails sent to yourself.
 
-- All messages in Inbox are treated as reminders. 
-- Subject (reminder) only are treated as reminders. 
+- All messages in Inbox are treated as reminders.
+- Subject (reminder) only are treated as reminders.
 - None (no reminders) is set to disabled.
 
 #### Email Bundling
+
 This option is used to bundle emails by label in the inbox.
 
 - Toggle On/Off
@@ -53,12 +55,16 @@ This option is used to bundle emails by label in the inbox.
 - Move Bundles to the top of your Inbox
 
 #### Avatars
+
 This option will show a circle with the first letter initial of the sender, to the left of the email in your folder.
-- Toggle  On/Off
+
+- Toggle On/Off
 
 #### Hide Priority Inbox Headings
+
 This option provides a cleEnable/Disableaner inbox UI if the "Priority Inbox" type is enabled via the settings
-- Toggle  On/Off
+
+- Toggle On/Off
 
 ## Recommended Gmail™ Settings
 
@@ -72,17 +78,17 @@ Using these settings will more closely replicate the visual style of Inbox:
 - Settings/General/Personal level indicators -> No indicators
 - Settings/Inbox/Importance markers -> No markers
 
-
 ## Email Bundling Tips
 
 Disable inbox category tabs:
+
 - Settings Dropdown/Configure Inbox -> Leave only Primary ticked -> Save
 
 Allow default category labels (Promotions, Social, Updates, Forums) to be bundled:
+
 - Settings/Labels/Categories/Show in message List -> Click Show for each category
 
 If you'd like a specific label not to be bundled, create a label called 'Unbundled', and nest that label within it.
-
 
 ## Known Issues
 

--- a/build.js
+++ b/build.js
@@ -17,30 +17,30 @@ const FILES_TO_INCLUDE = [
   'src',
   '.gitignore',
   'LICENSE',
-  'README.md'
+  'README.md',
 ];
 
 const BUILD_DIR = 'build';
 
-function getDesktopDir() {
-  // Cross-platform way to get desktop path
-  return path.join(os.homedir(), 'Desktop');
+function getOutputDir() {
+  // Defaults to the Desktop; override with BUILD_OUTPUT_DIR (used by CI)
+  return process.env.BUILD_OUTPUT_DIR || path.join(os.homedir(), 'Desktop');
 }
 
-function ensureDesktopDir() {
-  const desktopDir = getDesktopDir();
-  if (!fs.existsSync(desktopDir)) {
-    fs.ensureDirSync(desktopDir);
-    console.log(`Created Desktop directory at: ${desktopDir}`);
+function ensureOutputDir() {
+  const outputDir = getOutputDir();
+  if (!fs.existsSync(outputDir)) {
+    fs.ensureDirSync(outputDir);
+    console.log(`Created output directory at: ${outputDir}`);
   }
 }
 
 async function build(target) {
-  ensureDesktopDir();
+  ensureOutputDir();
 
   const manifestSrc = target === 'chrome' ? 'chrome.json' : 'firefox.json';
   const manifestDest = path.join(BUILD_DIR, 'manifest.json');
-  const zipName = path.join(getDesktopDir(), `inbox-reborn-${target}.zip`);
+  const zipName = path.join(getOutputDir(), `inbox-reborn-${target}.zip`);
 
   // Clean build dir
   await fs.remove(BUILD_DIR);
@@ -61,12 +61,14 @@ async function build(target) {
   const archive = archiver('zip', { zlib: { level: 9 } });
 
   output.on('close', () => {
-    console.log(`${zipName} created on Desktop (${archive.pointer()} total bytes)`);
+    console.log(`${zipName} created (${archive.pointer()} total bytes)`);
     // Optionally: clean up build folder
     fs.removeSync(BUILD_DIR);
   });
 
-  archive.on('error', err => { throw err; });
+  archive.on('error', (err) => {
+    throw err;
+  });
 
   archive.pipe(output);
   archive.directory(BUILD_DIR + '/', false);
@@ -74,11 +76,11 @@ async function build(target) {
 }
 
 async function buildUnpacked(target) {
-  ensureDesktopDir();
+  ensureOutputDir();
 
   const manifestSrc = target === 'chrome' ? 'chrome.json' : 'firefox.json';
-  const desktop = getDesktopDir();
-  const unpackedDir = path.join(desktop, `inbox-reborn-${target}`);
+  const outputDir = getOutputDir();
+  const unpackedDir = path.join(outputDir, `inbox-reborn-${target}`);
 
   // Clean and create the unpacked dir
   await fs.remove(unpackedDir);

--- a/build.js
+++ b/build.js
@@ -9,16 +9,8 @@ const path = require('path');
 const archiver = require('archiver');
 const os = require('os');
 
-const FILES_TO_INCLUDE = [
-  'docs',
-  'icons',
-  'images',
-  'screenshots',
-  'src',
-  '.gitignore',
-  'LICENSE',
-  'README.md',
-];
+// Only what the extension needs at runtime ships in the package
+const FILES_TO_INCLUDE = ['icons', 'images', 'src', 'LICENSE'];
 
 const BUILD_DIR = 'build';
 

--- a/chrome.json
+++ b/chrome.json
@@ -29,7 +29,7 @@
   ],
   "web_accessible_resources": [
     {
-      "resources": [ "images/*"],
+      "resources": ["images/*"],
       "matches": ["https://mail.google.com/*"]
     }
   ]

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,35 @@
+import js from '@eslint/js';
+import globals from 'globals';
+
+export default [
+  {
+    ignores: ['node_modules/', 'dist/', 'build/', 'docs/'],
+  },
+  js.configs.recommended,
+  {
+    files: ['src/**/*.js'],
+    languageOptions: {
+      ecmaVersion: 2023,
+      sourceType: 'script',
+      globals: {
+        ...globals.browser,
+        chrome: 'readonly',
+        browser: 'readonly',
+      },
+    },
+    rules: {
+      'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+      'no-var': 'error',
+      'prefer-const': 'error',
+      eqeqeq: ['error', 'smart'],
+    },
+  },
+  {
+    files: ['build.js'],
+    languageOptions: {
+      ecmaVersion: 2023,
+      sourceType: 'commonjs',
+      globals: globals.node,
+    },
+  },
+];

--- a/firefox.json
+++ b/firefox.json
@@ -36,19 +36,11 @@
   },
   "content_scripts": [
     {
-      "matches": [
-        "https://mail.google.com/mail/*"
-      ],
-      "css": [
-        "src/style.css"
-      ],
-      "js": [
-        "src/script.js"
-      ],
+      "matches": ["https://mail.google.com/mail/*"],
+      "css": ["src/style.css"],
+      "js": ["src/script.js"],
       "run_at": "document_start"
     }
   ],
-  "web_accessible_resources": [
-    "images/*"
-  ]
+  "web_accessible_resources": ["images/*"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3495 @@
+{
+  "name": "inbox-reborn",
+  "version": "2.1.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "inbox-reborn",
+      "version": "2.1.1",
+      "devDependencies": {
+        "@eslint/js": "^10.0.1",
+        "archiver": "^7.0.1",
+        "eslint": "^10.4.1",
+        "fs-extra": "^11.3.5",
+        "globals": "^17.6.0",
+        "prettier": "^3.8.4",
+        "stylelint": "^17.13.0",
+        "stylelint-config-standard": "^40.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cacheable/memory": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.9.tgz",
+      "integrity": "sha512-HdMx6DoGywB30vacDbBsITbIX4pgFqj1zsrV58jZBUw3klzkNoXhj7qOqAgledhxG7YZI5rBSJg7Zp8/VG0DuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/utils": "^2.4.1",
+        "@keyv/bigmap": "^1.3.1",
+        "hookified": "^1.15.1",
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@cacheable/memory/node_modules/@keyv/bigmap": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
+      "integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.4.0",
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@cacheable/memory/node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
+      }
+    },
+    "node_modules/@cacheable/utils": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.4.1.tgz",
+      "integrity": "sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.5.1",
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@cacheable/utils/node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
+      "integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/media-query-list-parser": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-5.0.0.tgz",
+      "integrity": "sha512-T9lXmZOfnam3eMERPsszjY5NK0jX8RmThmmm99FZ8b7z8yMaFZWKwLWGZuTwdO3ddRY5fy13GmmEYZXB4I98Eg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/selector-resolve-nested": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-4.0.0.tgz",
+      "integrity": "sha512-9vAPxmp+Dx3wQBIUwc1v7Mdisw1kbbaGqXUM8QLTgWg7SoPGYtXBsMXvsFs/0Bn5yoFhcktzxNZGNaUt0VjgjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^7.1.1"
+      }
+    },
+    "node_modules/@csstools/selector-specificity": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-6.0.0.tgz",
+      "integrity": "sha512-4sSgl78OtOXEX/2d++8A83zHNTgwCJMaR24FvsYL7Uf/VS8HZk9PTwR51elTbGqMuwH3szLvvOXEaVnqn0Z3zA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^7.1.1"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@keyv/serialize": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+      "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/archiver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
+      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.2",
+        "async": "^3.2.4",
+        "buffer-crc32": "^1.0.0",
+        "readable-stream": "^4.0.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^6.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
+      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^10.0.0",
+        "graceful-fs": "^4.2.0",
+        "is-stream": "^2.0.1",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.17.15",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
+      "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
+      "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
+      "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
+      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/cacheable": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.5.tgz",
+      "integrity": "sha512-EQfaKe09tl615iNvq/TBRWTFf1AKJNXYQSsMx0Z3EI0nA+pVsVPS8wJhnRlkbdacKPh1d0qVIhwTc2zsQNFEEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/memory": "^2.0.8",
+        "@cacheable/utils": "^2.4.1",
+        "hookified": "^1.15.0",
+        "keyv": "^5.6.0",
+        "qified": "^0.10.1"
+      }
+    },
+    "node_modules/cacheable/node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/colord": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
+      "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/compress-commons": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
+      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^6.0.0",
+        "is-stream": "^2.0.1",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cosmiconfig": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
+      "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
+      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/css-functions-list": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.3.3.tgz",
+      "integrity": "sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.1.tgz",
+      "integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.2",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastest-levenshtein": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.9.1"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/global-modules": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+      "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "global-prefix": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/global-prefix": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+      "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.5",
+        "kind-of": "^6.0.2",
+        "which": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/global-prefix/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.0.tgz",
+      "integrity": "sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "fast-glob": "^3.3.3",
+        "ignore": "^7.0.5",
+        "is-path-inside": "^4.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/globjoin": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
+      "integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-5.0.1.tgz",
+      "integrity": "sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/hashery": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz",
+      "integrity": "sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/hookified": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
+      "integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-tags": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-5.1.0.tgz",
+      "integrity": "sha512-n6l5uca7/y5joxZ3LUePhzmBFUJ+U2YWzhMa8XUTecSeSlQiZdF5XAd/Q3/WUl0VsXgUwWi8I7CNIwdI5WN1SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/mathml-tag-names": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-4.0.0.tgz",
+      "integrity": "sha512-aa6AU2Pcx0VP/XWnh8IGL0SYSgQHDT6Ucror2j2mXeFAlN3ahaNs8EZtG1YiticMkSLj3Gt6VPFfZogt7G5iFQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/meow": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-14.1.0.tgz",
+      "integrity": "sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-safe-parser": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.1.tgz",
+      "integrity": "sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss-safe-parser"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.31"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.2.tgz",
+      "integrity": "sha512-Wjvt4scRFouioIInHf51IFNP4ltJ2EngJM+cZPGiqbKetBfmP3vpdPV8ID2S6JS6/jdo74N8+aEYH9lQr2C6sA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qified": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/qified/-/qified-0.10.1.tgz",
+      "integrity": "sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/qified/node_modules/hookified": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-2.2.0.tgz",
+      "integrity": "sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.27.0.tgz",
+      "integrity": "sha512-WZ189TKnHoAokYHvwzaAQMpd55cgUmFIcJFzBSgGcb886jau5DL+XdDhTWV4ps3FLvk+OORp0dLRTPsLZ21CSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/stylelint": {
+      "version": "17.13.0",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-17.13.0.tgz",
+      "integrity": "sha512-G1WYzMerp7ihOaIe9VJCHLt12MoAD2QLf1AFerYP37+BCRBUK5UCpq8e/mN+zCIaJPKQcaxhE4WlPmqdiOx/gw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/stylelint"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/stylelint"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.2.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.4",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "@csstools/media-query-list-parser": "^5.0.0",
+        "@csstools/selector-resolve-nested": "^4.0.0",
+        "@csstools/selector-specificity": "^6.0.0",
+        "colord": "^2.9.3",
+        "cosmiconfig": "^9.0.1",
+        "css-functions-list": "^3.3.3",
+        "css-tree": "^3.2.1",
+        "debug": "^4.4.3",
+        "fast-glob": "^3.3.3",
+        "fastest-levenshtein": "^1.0.16",
+        "file-entry-cache": "^11.1.3",
+        "global-modules": "^2.0.0",
+        "globby": "^16.2.0",
+        "globjoin": "^0.1.4",
+        "html-tags": "^5.1.0",
+        "ignore": "^7.0.5",
+        "import-meta-resolve": "^4.2.0",
+        "mathml-tag-names": "^4.0.0",
+        "meow": "^14.1.0",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.5.15",
+        "postcss-safe-parser": "^7.0.1",
+        "postcss-selector-parser": "^7.1.1",
+        "postcss-value-parser": "^4.2.0",
+        "string-width": "^8.2.1",
+        "supports-hyperlinks": "^4.4.0",
+        "svg-tags": "^1.0.0",
+        "table": "^6.9.0",
+        "write-file-atomic": "^7.0.1"
+      },
+      "bin": {
+        "stylelint": "bin/stylelint.mjs"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/stylelint-config-recommended": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-18.0.0.tgz",
+      "integrity": "sha512-mxgT2XY6YZ3HWWe3Di8umG6aBmWmHTblTgu/f10rqFXnyWxjKWwNdjSWkgkwCtxIKnqjSJzvFmPT5yabVIRxZg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/stylelint"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/stylelint"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "stylelint": "^17.0.0"
+      }
+    },
+    "node_modules/stylelint-config-standard": {
+      "version": "40.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-40.0.0.tgz",
+      "integrity": "sha512-EznGJxOUhtWck2r6dJpbgAdPATIzvpLdK9+i5qPd4Lx70es66TkBPljSg4wN3Qnc6c4h2n+WbUrUynQ3fanjHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/stylelint"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/stylelint"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "stylelint-config-recommended": "^18.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "stylelint": "^17.0.0"
+      }
+    },
+    "node_modules/stylelint/node_modules/file-entry-cache": {
+      "version": "11.1.3",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.3.tgz",
+      "integrity": "sha512-oMbq0PD6VIiIwMF6LIa7MEwd/l9huKwmqRKXqmrkqIZv8CvRbfowL+L0ryAl8h//HfAS0zS+4SbYoRyAoA6BJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^6.1.22"
+      }
+    },
+    "node_modules/stylelint/node_modules/flat-cache": {
+      "version": "6.1.22",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.22.tgz",
+      "integrity": "sha512-N2dnzVJIphnNsjHcrxGW7DePckJ6haPrSFqpsBUhHYgwtKGVq4JrBGielEGD2fCVnsGm1zlBVZ8wGhkyuetgug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cacheable": "^2.3.4",
+        "flatted": "^3.4.2",
+        "hookified": "^1.15.0"
+      }
+    },
+    "node_modules/stylelint/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/supports-hyperlinks": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-4.4.0.tgz",
+      "integrity": "sha512-UKbpT93hN5Nr9go5UY7bopIB9YQlMz9nm/ct4IXt/irb5YRkn9WaqrOBJGZ5Pwvsd5FQzSVeYlGdXoCAPQZrPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^5.0.1",
+        "supports-color": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
+      }
+    },
+    "node_modules/svg-tags": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
+      "integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
+      "dev": true
+    },
+    "node_modules/table": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
+      "integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/table/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/table/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/table/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
+      "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/write-file-atomic": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-7.0.1.tgz",
+      "integrity": "sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
+      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.0",
+        "compress-commons": "^6.0.2",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "inbox-reborn",
+  "version": "2.1.1",
+  "private": true,
+  "description": "Build and quality tooling for the Inbox Reborn theme for Gmail extension",
+  "scripts": {
+    "build": "npm run build:chrome && npm run build:firefox",
+    "build:chrome": "node build.js chrome zip",
+    "build:firefox": "node build.js firefox zip",
+    "build:chrome:unpacked": "node build.js chrome unpacked",
+    "build:firefox:unpacked": "node build.js firefox unpacked",
+    "lint": "npm run lint:js && npm run lint:css && npm run format:check",
+    "lint:js": "eslint .",
+    "lint:css": "stylelint \"src/**/*.css\"",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
+  },
+  "devDependencies": {
+    "@eslint/js": "^10.0.1",
+    "archiver": "^7.0.1",
+    "eslint": "^10.4.1",
+    "fs-extra": "^11.3.5",
+    "globals": "^17.6.0",
+    "prettier": "^3.8.4",
+    "stylelint": "^17.13.0",
+    "stylelint-config-standard": "^40.0.0"
+  }
+}

--- a/src/background.js
+++ b/src/background.js
@@ -1,18 +1,18 @@
 // Polyfill for cross-browser compatibility
-const browserAPI = (typeof browser !== 'undefined') ? browser : chrome;
+const browserAPI = typeof browser !== 'undefined' ? browser : chrome;
 
-browserAPI.runtime.onMessage.addListener(function(request, sender, sendResponse) {
-    if (request.method === 'getOptions') {
-        browserAPI.storage.local.get('options', function(result) {
-            const options = result.options || {};
-            options.reminderTreatment = options.reminderTreatment || 'containing-word';
-            options.emailBundling = options.emailBundling || 'enabled';
-            options.showAvatar = options.showAvatar || 'enabled';
+browserAPI.runtime.onMessage.addListener(function (request, sender, sendResponse) {
+  if (request.method === 'getOptions') {
+    browserAPI.storage.local.get('options', function (result) {
+      const options = result.options || {};
+      options.reminderTreatment = options.reminderTreatment || 'containing-word';
+      options.emailBundling = options.emailBundling || 'enabled';
+      options.showAvatar = options.showAvatar || 'enabled';
 
-            sendResponse(options);
-        });
-        return true; // Indicates that sendResponse will be called asynchronously
-    } else {
-        sendResponse({});
-    }
+      sendResponse(options);
+    });
+    return true; // Indicates that sendResponse will be called asynchronously
+  } else {
+    sendResponse({});
+  }
 });

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -1,23 +1,25 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
-<meta charset="UTF-8">
-<title>Inbox in Gmail Options</title>
-</head>
-<link rel="stylesheet" href="style.css">
-<body>
-<div class="content">
-    <div class="setting">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Inbox in Gmail Options</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="content">
+      <div class="setting">
         <div class="setting-title">Dark Mode</div>
         <div class="setting-content">
-            <span class="setting-desc">Use with Gmail’s Dark Theme (enable dark mode in Gmail settings as well)</span>
-            <label class="switch">
-              <input type="checkbox" id="dark-mode-toggle">
-              <span class="slider round"></span>
-            </label>
+          <span class="setting-desc"
+            >Use with Gmail’s Dark Theme (enable dark mode in Gmail settings as well)</span
+          >
+          <label class="switch">
+            <input type="checkbox" id="dark-mode-toggle" />
+            <span class="slider round"></span>
+          </label>
         </div>
-    </div>
-    <div class="setting">
+      </div>
+      <div class="setting">
         <div class="setting-title">Reminders</div>
         <div class="setting-content">
           <span class="setting-desc">Select how emails sent to yourself are displayed</span>
@@ -27,48 +29,48 @@
             <option value="none">None (no reminders)</option>
           </select>
         </div>
-    </div>
-    <div class="setting">
+      </div>
+      <div class="setting">
         <div class="setting-title">Email Bundling</div>
         <div class="setting-content">
-            <span class="setting-desc">Group emails in your inbox by label</span>
-            <label class="switch">
-              <input type="checkbox" id="bundling-toggle">
-              <span class="slider round"></span>
-            </label>
+          <span class="setting-desc">Group emails in your inbox by label</span>
+          <label class="switch">
+            <input type="checkbox" id="bundling-toggle" />
+            <span class="slider round"></span>
+          </label>
         </div>
         <div class="sub-settings">
-            <label>
-                <input type="checkbox" name="bundle-one" id="bundle-one">
-                Show bundle if only one email (Requires refresh when turning off)</small>
-            </label>
-            <label>
-                <input type="checkbox" name="bundle-top" id="bundle-top">
-                Move bundles to top of inbox
-            </label>
+          <label>
+            <input type="checkbox" name="bundle-one" id="bundle-one" />
+            Show bundle if only one email (Requires refresh when turning off)
+          </label>
+          <label>
+            <input type="checkbox" name="bundle-top" id="bundle-top" />
+            Move bundles to top of inbox
+          </label>
         </div>
-    </div>
-    <div class="setting">
+      </div>
+      <div class="setting">
         <div class="setting-title">Avatars</div>
         <div class="setting-content">
-            <span class="setting-desc">Show a colored circle with the sender’s first initial</span>
-            <label class="switch">
-              <input type="checkbox" id="avatar-toggle">
-              <span class="slider round"></span>
-            </label>
+          <span class="setting-desc">Show a colored circle with the sender’s first initial</span>
+          <label class="switch">
+            <input type="checkbox" id="avatar-toggle" />
+            <span class="slider round"></span>
+          </label>
         </div>
-    </div>
-    <div class="setting">
+      </div>
+      <div class="setting">
         <div class="setting-title">Hide Priority Inbox Headings</div>
         <div class="setting-content">
-            <span class="setting-desc">Clean up the inbox UI when using “Priority Inbox” view</span>
-            <label class="switch">
-              <input type="checkbox" id="priority-inbox-toggle">
-              <span class="slider round"></span>
-            </label>
+          <span class="setting-desc">Clean up the inbox UI when using “Priority Inbox” view</span>
+          <label class="switch">
+            <input type="checkbox" id="priority-inbox-toggle" />
+            <span class="slider round"></span>
+          </label>
         </div>
+      </div>
     </div>
-</div>
-<script src="script.js"></script>
-</body>
+    <script src="script.js"></script>
+  </body>
 </html>

--- a/src/options/script.js
+++ b/src/options/script.js
@@ -42,9 +42,7 @@ function saveOptions() {
     darkMode,
   };
 
-  browserAPI.storage.local.set({ options: options }, function () {
-    console.log('Options saved:', options);
-  });
+  browserAPI.storage.local.set({ options: options });
 }
 
 function restoreOptions() {

--- a/src/options/script.js
+++ b/src/options/script.js
@@ -1,86 +1,94 @@
-const browserAPI = (typeof chrome !== 'undefined' && chrome.runtime && typeof chrome.runtime.sendMessage === 'function')
+const browserAPI =
+  typeof chrome !== 'undefined' &&
+  chrome.runtime &&
+  typeof chrome.runtime.sendMessage === 'function'
     ? chrome
-    : (typeof browser !== 'undefined' ? browser : chrome);
+    : typeof browser !== 'undefined'
+      ? browser
+      : chrome;
 
-const REMINDER_TREATMENT_SELECTOR = 'input[name=reminder-treatment]';
 const REMINDER_SELECT_SELECTOR = '#reminder-select';
-const BUNDLED_EMAIL_SELECTOR = 'input[name=email-bundling]';
 const BUNDLE_ONE_SELECTOR = 'input[name=bundle-one]';
 const BUNDLE_TOP_SELECTOR = 'input[name=bundle-top]';
-const AVATAR_SELECTOR = 'input[name=avatar]';
 const AVATAR_TOGGLE_SELECTOR = '#avatar-toggle';
-const PRIORITY_INBOX_SELECTOR = 'input[name=priority-inbox]';
 const PRIORITY_INBOX_TOGGLE_SELECTOR = '#priority-inbox-toggle';
-const DARK_MODE_SELECTOR = 'input[name=dark-mode]';
 const DARK_MODE_TOGGLE_SELECTOR = '#dark-mode-toggle';
 const BUNDLING_TOGGLE_SELECTOR = '#bundling-toggle';
 
 function saveOptions() {
-	const reminderTreatment = document.querySelector(REMINDER_SELECT_SELECTOR).value;
-	const emailBundling = document.querySelector(BUNDLING_TOGGLE_SELECTOR).checked ? 'enabled' : 'disabled';
-	const bundleOne = getCheckboxState(BUNDLE_ONE_SELECTOR);
-	const bundleTop = getCheckboxState(BUNDLE_TOP_SELECTOR);
-	const showAvatar = document.querySelector(AVATAR_TOGGLE_SELECTOR).checked ? 'enabled' : 'disabled';
-	const priorityInbox = document.querySelector(PRIORITY_INBOX_TOGGLE_SELECTOR).checked ? 'enabled' : 'disabled';
-	const darkMode = document.querySelector(DARK_MODE_TOGGLE_SELECTOR).checked ? 'enabled' : 'disabled';
+  const reminderTreatment = document.querySelector(REMINDER_SELECT_SELECTOR).value;
+  const emailBundling = document.querySelector(BUNDLING_TOGGLE_SELECTOR).checked
+    ? 'enabled'
+    : 'disabled';
+  const bundleOne = getCheckboxState(BUNDLE_ONE_SELECTOR);
+  const bundleTop = getCheckboxState(BUNDLE_TOP_SELECTOR);
+  const showAvatar = document.querySelector(AVATAR_TOGGLE_SELECTOR).checked
+    ? 'enabled'
+    : 'disabled';
+  const priorityInbox = document.querySelector(PRIORITY_INBOX_TOGGLE_SELECTOR).checked
+    ? 'enabled'
+    : 'disabled';
+  const darkMode = document.querySelector(DARK_MODE_TOGGLE_SELECTOR).checked
+    ? 'enabled'
+    : 'disabled';
 
-	const options = { reminderTreatment, emailBundling, bundleOne, bundleTop, showAvatar, priorityInbox, darkMode };
+  const options = {
+    reminderTreatment,
+    emailBundling,
+    bundleOne,
+    bundleTop,
+    showAvatar,
+    priorityInbox,
+    darkMode,
+  };
 
-	browserAPI.storage.local.set({ 'options': options }, function() {
+  browserAPI.storage.local.set({ options: options }, function () {
     console.log('Options saved:', options);
-});
+  });
 }
 
 function restoreOptions() {
-	browserAPI.runtime.sendMessage({ method: 'getOptions' }, function(options) {
-		document.querySelector(REMINDER_SELECT_SELECTOR).value = options.reminderTreatment;
-		document.querySelector(BUNDLING_TOGGLE_SELECTOR).checked = options.emailBundling === 'enabled';
-		setCheckbox(BUNDLE_ONE_SELECTOR, options.bundleOne);
-		setCheckbox(BUNDLE_TOP_SELECTOR, options.bundleTop);
-		document.querySelector(AVATAR_TOGGLE_SELECTOR).checked = options.showAvatar === 'enabled';
-		document.querySelector(PRIORITY_INBOX_TOGGLE_SELECTOR).checked = options.priorityInbox === 'enabled';
-		document.querySelector(DARK_MODE_TOGGLE_SELECTOR).checked = options.darkMode === 'enabled';
-		document.body.classList.toggle('dark-mode', options.darkMode === 'enabled');
-		
-		const bundlingEnabled = options.emailBundling === 'enabled';
-		document.querySelectorAll('.sub-settings input').forEach(cb => {
-		  cb.disabled = !bundlingEnabled;
-		});
-	});
-}
+  browserAPI.runtime.sendMessage({ method: 'getOptions' }, function (options) {
+    document.querySelector(REMINDER_SELECT_SELECTOR).value = options.reminderTreatment;
+    document.querySelector(BUNDLING_TOGGLE_SELECTOR).checked = options.emailBundling === 'enabled';
+    setCheckbox(BUNDLE_ONE_SELECTOR, options.bundleOne);
+    setCheckbox(BUNDLE_TOP_SELECTOR, options.bundleTop);
+    document.querySelector(AVATAR_TOGGLE_SELECTOR).checked = options.showAvatar === 'enabled';
+    document.querySelector(PRIORITY_INBOX_TOGGLE_SELECTOR).checked =
+      options.priorityInbox === 'enabled';
+    document.querySelector(DARK_MODE_TOGGLE_SELECTOR).checked = options.darkMode === 'enabled';
+    document.body.classList.toggle('dark-mode', options.darkMode === 'enabled');
 
-function selectRadioWithValue(selector, value) {
-	document.querySelectorAll(selector).forEach(radioInput => {
-		if(radioInput.value === value) radioInput.checked = true;
-	});
+    const bundlingEnabled = options.emailBundling === 'enabled';
+    document.querySelectorAll('.sub-settings input').forEach((cb) => {
+      cb.disabled = !bundlingEnabled;
+    });
+  });
 }
 
 function setCheckbox(selector, value) {
-	document.querySelector(selector).checked = !!value;
+  document.querySelector(selector).checked = !!value;
 }
 
-const getSelectedRadioValue = selector => document.querySelector(selector + ':checked').value;
-const getCheckboxState = selector => document.querySelector(selector).checked;
+const getCheckboxState = (selector) => document.querySelector(selector).checked;
 
-const monitorChange = element => element.addEventListener('click', saveOptions);
+const monitorChange = (element) => element.addEventListener('click', saveOptions);
 
 document.addEventListener('DOMContentLoaded', restoreOptions);
 document.querySelector(REMINDER_SELECT_SELECTOR).addEventListener('change', saveOptions);
-// Removed monitoring for BUNDLED_EMAIL_SELECTOR radios since replaced by toggle
 monitorChange(document.querySelector(BUNDLE_ONE_SELECTOR));
 monitorChange(document.querySelector(BUNDLE_TOP_SELECTOR));
-// document.querySelectorAll(AVATAR_SELECTOR).forEach(monitorChange);
-// document.querySelectorAll(PRIORITY_INBOX_SELECTOR).forEach(monitorChange);
 document.querySelector(DARK_MODE_TOGGLE_SELECTOR).addEventListener('change', () => {
   saveOptions();
-  document.body.classList.toggle('dark-mode',
-    document.querySelector(DARK_MODE_TOGGLE_SELECTOR).checked
+  document.body.classList.toggle(
+    'dark-mode',
+    document.querySelector(DARK_MODE_TOGGLE_SELECTOR).checked,
   );
 });
 const bundlingToggle = document.querySelector(BUNDLING_TOGGLE_SELECTOR);
 bundlingToggle.addEventListener('change', () => {
   saveOptions();
-  document.querySelectorAll('.sub-settings input').forEach(cb => {
+  document.querySelectorAll('.sub-settings input').forEach((cb) => {
     cb.disabled = !bundlingToggle.checked;
   });
 });

--- a/src/options/style.css
+++ b/src/options/style.css
@@ -12,64 +12,68 @@
   flex: 1;
   margin-right: 12px;
 }
+
 body {
-    font-family: Roboto, system-ui, sans-serif;
-    font-size: 13px;
-    margin: 0;
+  font-family: Roboto, system-ui, sans-serif;
+  font-size: 13px;
+  margin: 0;
 }
 
 .content {
-    background-color: white;
-    padding: 0 20px;
-    width: 550px;
-    max-width:100%;
-    box-sizing: border-box;
+  background-color: white;
+  padding: 0 20px;
+  width: 550px;
+  max-width: 100%;
+  box-sizing: border-box;
 }
 
-.label{
-    display:inline-block;
-    width: 90%;
-    vertical-align:top;
-    padding-top: 0.2em;
-    padding-left: 2px;
+.label {
+  display: inline-block;
+  width: 90%;
+  vertical-align: top;
+  padding-top: 0.2em;
+  padding-left: 2px;
 }
 
 .settings-wrapper {
-    margin-top: 36px;
+  margin-top: 36px;
 }
 
 .setting {
-    padding: 12px 20px;
-    border-bottom: 1px solid rgb(224, 224, 224);
-    margin: 0 -10px 0 -20px;
+  padding: 12px 20px;
+  border-bottom: 1px solid rgb(224 224 224);
+  margin: 0 -10px 0 -20px;
 }
 
 .setting:nth-last-child(1) {
-    border-bottom:none;
-    padding-bottom:30px;
+  border-bottom: none;
+  padding-bottom: 30px;
 }
 
 .setting-title {
-    font-weight: bold;
-    margin-bottom: 5px;
+  font-weight: bold;
+  margin-bottom: 5px;
 }
 
 .setting-content {
-    color: #616161;
+  color: #616161;
 }
 
 body.dark-mode {
-    background-color: #303030;
-    color: #fafafa;
+  background-color: #303030;
+  color: #fafafa;
 }
+
 body.dark-mode .content {
-    background-color: #424242;
+  background-color: #424242;
 }
+
 body.dark-mode .setting {
-    border-color: #555;
+  border-color: #555;
 }
+
 body.dark-mode .setting-content {
-    color: #ccc;
+  color: #ccc;
 }
 
 .switch {
@@ -79,7 +83,7 @@ body.dark-mode .setting-content {
   height: 17px;
 }
 
-.switch input { 
+.switch input {
   opacity: 0;
   width: 0;
   height: 0;
@@ -93,20 +97,20 @@ body.dark-mode .setting-content {
   right: 0;
   bottom: 0;
   background-color: #ccc;
-  -webkit-transition: .4s;
-  transition: .4s;
+  -webkit-transition: 0.4s;
+  transition: 0.4s;
 }
 
-.slider:before {
+.slider::before {
   position: absolute;
-  content: "";
+  content: '';
   height: 13px;
   width: 13px;
   left: 2px;
   bottom: 2px;
   background-color: white;
-  -webkit-transition: .4s;
-  transition: .4s;
+  -webkit-transition: 0.4s;
+  transition: 0.4s;
 }
 
 input:checked + .slider {
@@ -117,7 +121,7 @@ input:focus + .slider {
   box-shadow: 0 0 1px #4285f4;
 }
 
-input:checked + .slider:before {
+input:checked + .slider::before {
   -webkit-transform: translateX(13px);
   -ms-transform: translateX(13px);
   transform: translateX(13px);
@@ -128,7 +132,7 @@ input:checked + .slider:before {
   border-radius: 34px;
 }
 
-.slider.round:before {
+.slider.round::before {
   border-radius: 50%;
 }
 

--- a/src/options/style.css
+++ b/src/options/style.css
@@ -35,10 +35,6 @@ body {
   padding-left: 2px;
 }
 
-.settings-wrapper {
-  margin-top: 36px;
-}
-
 .setting {
   padding: 12px 20px;
   border-bottom: 1px solid rgb(224 224 224);

--- a/src/script.js
+++ b/src/script.js
@@ -1,6 +1,6 @@
 /**
  * Gmail Enhancement Script
- * 
+ *
  * This script enhances the Gmail interface with additional features:
  * - Dark mode synchronization
  * - Email bundling and organization
@@ -10,7 +10,7 @@
  * - Custom sidebar with improved navigation
  * - Reminder functionality
  * - UI enhancements and Material Design icons
- * 
+ *
  * Version: 2.0.0
  * Last Updated: 2025
  */
@@ -47,34 +47,56 @@
  * Date and time constants
  */
 const MONTHS = [
-  'January', 'February', 'March', 'April', 'May', 'June',
-  'July', 'August', 'September', 'October', 'November', 'December'
-];
-
-const DAYS = [
-  'Sunday', 'Monday', 'Tuesday', 'Wednesday',
-  'Thursday', 'Friday', 'Saturday'
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
 ];
 
 /**
  * Avatar color palette for user initials
  */
 const NAME_COLORS = [
-  '1bbc9b', '16a086', 'f1c40f', 'f39c11', '2dcc70', '27ae61',
-  'd93939', 'd25400', '3598db', '297fb8', 'e84c3d', 'c1392b',
-  '9a59b5', '8d44ad', 'bec3c7', '34495e', '2d3e50', '95a5a4',
-  '7e8e8e', 'ec87bf', 'd870ad', 'f69785', '9ba37e', 'b49255',
-  'b49255', 'a94136'
+  '1bbc9b',
+  '16a086',
+  'f1c40f',
+  'f39c11',
+  '2dcc70',
+  '27ae61',
+  'd93939',
+  'd25400',
+  '3598db',
+  '297fb8',
+  'e84c3d',
+  'c1392b',
+  '9a59b5',
+  '8d44ad',
+  'bec3c7',
+  '34495e',
+  '2d3e50',
+  '95a5a4',
+  '7e8e8e',
+  'ec87bf',
+  'd870ad',
+  'f69785',
+  '9ba37e',
+  'b49255',
+  'b49255',
+  'a94136',
 ];
 
 /**
  * Domains that are known to be slow or problematic - skip them
  */
-const SKIP_DOMAINS = new Set([
-  'gmail.com',
-  'google.com',
-  'googleusercontent.com'
-]);
+const SKIP_DOMAINS = new Set(['gmail.com', 'google.com', 'googleusercontent.com']);
 
 /**
  * Avatar cache to avoid repeated API calls
@@ -102,8 +124,6 @@ const CSS_CLASSES = {
   LETTER_AVATAR: 'letter-avatar',
   STYLE_NODE_ID_PREFIX: 'hide-email-',
   PRIORITY_INBOX_OPTION: 'priority-inbox-enabled',
-
-
 };
 
 /**
@@ -113,13 +133,12 @@ const DATE_LABELS = {
   TODAY: 'Today',
   YESTERDAY: 'Yesterday',
   THIS_MONTH: 'This month',
-  LAST_YEAR: 'Last year'
+  LAST_YEAR: 'Last year',
 };
 
 /**
  * Material icon mapping for sidebar items
  */
-
 
 // =============================================================================
 // ELEMENT SELECTORS
@@ -127,7 +146,7 @@ const DATE_LABELS = {
 
 /**
  * Centralized DOM element selectors
- * 
+ *
  * All the selectors for Gmail elements in one place
  * so that when they inevitably break, they can be corrected.
  * This also makes it easier for implementing more reliable
@@ -135,52 +154,52 @@ const DATE_LABELS = {
  */
 const select = {
   // General UI elements
-  emailAddress:        () => document.querySelector("a[aria-label^='Google Account:']"),
-  tabs:                () => document.querySelectorAll('.aKz'),
-  bundleWrappers:      () => document.querySelectorAll('.oy8Mbf[role=main] .bundle-wrapper'),
-  inbox:               () => document.querySelector('.nZ[data-tooltip=Inbox]'),
-  importanceMarkers:   () => document.querySelector('td.WA.xY'),
-  emails:              () => document.querySelectorAll('.oy8Mbf .zA'),
-  currentTab:          () => document.querySelector('.aAy[aria-selected="true"]'),
-  
+  emailAddress: () => document.querySelector("a[aria-label^='Google Account:']"),
+  tabs: () => document.querySelectorAll('.aKz'),
+  bundleWrappers: () => document.querySelectorAll('.oy8Mbf[role=main] .bundle-wrapper'),
+  inbox: () => document.querySelector('.nZ[data-tooltip=Inbox]'),
+  importanceMarkers: () => document.querySelector('td.WA.xY'),
+  emails: () => document.querySelectorAll('.oy8Mbf .zA'),
+  currentTab: () => document.querySelector('.aAy[aria-selected="true"]'),
+
   // Menu elements
-  menu:                () => document.body.querySelector('.J-Ke.n4.ah9'),
-  composeButtonNew:    () => document.querySelector('.Yh.akV'),
-  composeButtonOld:    () => document.querySelector('.T-I.T-I-KE.L3'),
-  composeButton:       () => select.composeButtonOld() || select.composeButtonNew(),
-  menuParent:          () => document.querySelector('.wT .byl'),
-  menuRefer:           () => document.querySelector('.wT .byl>.TK'),
-  
+  menu: () => document.body.querySelector('.J-Ke.n4.ah9'),
+  composeButtonNew: () => document.querySelector('.Yh.akV'),
+  composeButtonOld: () => document.querySelector('.T-I.T-I-KE.L3'),
+  composeButton: () => select.composeButtonOld() || select.composeButtonNew(),
+  menuParent: () => document.querySelector('.wT .byl'),
+  menuRefer: () => document.querySelector('.wT .byl>.TK'),
+
   // Header elements
-  titleNode:           () => document.querySelectorAll('a[aria-label="Gmail"]')[1],
-  headerElement:       () => document.querySelector('.w-asV.bbg.aiw'),
-  
+  titleNode: () => document.querySelectorAll('a[aria-label="Gmail"]')[1],
+  headerElement: () => document.querySelector('.w-asV.bbg.aiw'),
+
   // Compose elements
-  messageBody:         () => document.querySelector('div[aria-label="Message Body"]'),
-  messageFrom:         () => document.querySelector('input[name="from"]'),
-  messageSubjectBox:   () => document.querySelector('input[name=subjectbox]'),
-  
+  messageBody: () => document.querySelector('div[aria-label="Message Body"]'),
+  messageFrom: () => document.querySelector('input[name="from"]'),
+  messageSubjectBox: () => document.querySelector('input[name=subjectbox]'),
+
   // Email-specific elements (require email element as parameter)
-  emailParticipants:   (email) => email.querySelectorAll('.yW span[email]'),
-  emailTitleNode:      (email) => email.querySelector('.y6'),
-  eventTitle:          (email) => email.querySelector('.bqe, .bog'),
-  emailCalendarEvent:  (email) => email.querySelector('.aKS .aJ6'),
-  emailDate:           (email) => email.querySelector('.xW.xY span'),
+  emailParticipants: (email) => email.querySelectorAll('.yW span[email]'),
+  emailTitleNode: (email) => email.querySelector('.y6'),
+  eventTitle: (email) => email.querySelector('.bqe, .bog'),
+  emailCalendarEvent: (email) => email.querySelector('.aKS .aJ6'),
+  emailDate: (email) => email.querySelector('.xW.xY span'),
   emailSubjectWrapper: (email) => email.querySelectorAll('.a4W'),
-  emailAction:         (email) => email.querySelector('.aKS'),
-  emailLabels:         (email) => email.querySelectorAll('.ar .at'),
-  emailLabelEls:       (email) => email.querySelectorAll('.at'),
-  emailAllLabels:      (email) => email.querySelectorAll('.ar.as'),
-  emailSnoozed:        (email) => email.querySelector('.by1.cL'),
-  emailStarred:        (email) => email.querySelector('.T-KT.T-KT-Jp'),
-  emailAvatarWrapper:  (email) => email.querySelector('.oZ-x3'),
-  emailMiscPart1:      (email) => email.querySelectorAll('.y2'),
-  emailMiscPart2:      (email) => email.querySelectorAll('.yP,.zF'),
-  emailMiscPart3:      (email) => email.querySelectorAll('.Zt'),
-  
+  emailAction: (email) => email.querySelector('.aKS'),
+  emailLabels: (email) => email.querySelectorAll('.ar .at'),
+  emailLabelEls: (email) => email.querySelectorAll('.at'),
+  emailAllLabels: (email) => email.querySelectorAll('.ar.as'),
+  emailSnoozed: (email) => email.querySelector('.by1.cL'),
+  emailStarred: (email) => email.querySelector('.T-KT.T-KT-Jp'),
+  emailAvatarWrapper: (email) => email.querySelector('.oZ-x3'),
+  emailMiscPart1: (email) => email.querySelectorAll('.y2'),
+  emailMiscPart2: (email) => email.querySelectorAll('.yP,.zF'),
+  emailMiscPart3: (email) => email.querySelectorAll('.Zt'),
+
   // Label-specific elements (require label element as parameter)
-  labelTitle:          (label) => label.querySelector('.at'),
-  labelInnerText:      (label) => label.querySelector('.av'),
+  labelTitle: (label) => label.querySelector('.at'),
+  labelInnerText: (label) => label.querySelector('.av'),
 };
 
 // =============================================================================
@@ -190,14 +209,10 @@ const select = {
 /**
  * Global state variables
  */
-let lastEmailCount = 0;
-let lastRefresh = new Date();
-let loadedMenu = false;
 let labelStats = {};
-let hiddenEmailIds = [];
+const hiddenEmailIds = [];
 let options = {};
-let menuNodes = {};
-
+const menuNodes = {};
 
 // =============================================================================
 // UTILITY FUNCTIONS
@@ -207,7 +222,7 @@ let menuNodes = {};
  * Add remove method to Element prototype if not exists
  */
 if (!Element.prototype.remove) {
-  Element.prototype.remove = function() {
+  Element.prototype.remove = function () {
     this.parentElement.removeChild(this);
   };
 }
@@ -220,7 +235,7 @@ const getMyEmailAddress = () => {
   const emailAddr = select.emailAddress();
   const emailAddress = emailAddr && emailAddr.getAttribute('aria-label');
   const emailAddressText = emailAddress && emailAddress.match(/.*?\((.*?)\)/)?.[1];
-  return emailAddressText || "";
+  return emailAddressText || '';
 };
 
 /**
@@ -251,14 +266,14 @@ const extractDomain = (email) => {
  */
 const getMainDomain = (domain) => {
   if (!domain) return '';
-  
+
   // Remove www. prefix if present
   domain = domain.replace(/^www\./, '');
-  
+
   // Split by dots and get last 2 parts for most domains
   const parts = domain.split('.');
   if (parts.length <= 2) return domain;
-  
+
   // Handle special cases like .co.uk, .com.au, etc.
   const specialTLDs = ['.co.uk', '.com.au', '.co.jp', '.co.za', '.com.br'];
   for (const tld of specialTLDs) {
@@ -268,7 +283,7 @@ const getMainDomain = (domain) => {
       return tldParts.slice(-1)[0] + tld;
     }
   }
-  
+
   // Default: last 2 parts
   return parts.slice(-2).join('.');
 };
@@ -286,31 +301,19 @@ const testImageUrl = (url) => {
       img.onerror = null;
       resolve(null);
     }, 2000);
-    
+
     img.onload = () => {
       clearTimeout(timeout);
       resolve(url);
     };
-    
+
     img.onerror = () => {
       clearTimeout(timeout);
       resolve(null);
     };
-    
+
     img.src = url;
   });
-};
-
-/**
- * Triggers a mouse event on a DOM node
- * @param {Element} node - The DOM node to trigger the event on
- * @param {string} event - The event name (e.g., 'click', 'mouseup')
- */
-const triggerMouseEvent = (node, event) => {
-  if (!node) return;
-  const mouseEvent = document.createEvent('MouseEvents');
-  mouseEvent.initEvent(event, true, true);
-  node.dispatchEvent(mouseEvent);
 };
 
 /**
@@ -349,7 +352,7 @@ const queryParentSelector = (elm, sel) => {
  * @param {string} label - The label name to encode
  * @returns {string} URL-encoded label name
  */
-const fixLabel = label => encodeURIComponent(label.replace(/[\/\\& ]/g, '-'));
+const fixLabel = (label) => encodeURIComponent(label.replace(/[/\\& ]/g, '-'));
 
 // =============================================================================
 // EMAIL CLASSIFICATION FUNCTIONS
@@ -414,7 +417,7 @@ const isSnoozed = (email, curDate, prevDate) => {
  * @param {Element} email - The email DOM element
  * @returns {boolean} True if the email is starred
  */
-const isStarred = email => {
+const isStarred = (email) => {
   const node = select.emailStarred(email);
   return node && node.ariaLabel !== 'Not starred';
 };
@@ -450,15 +453,15 @@ const checkImportantMarkers = () => select.importanceMarkers();
  * @param {string[]} labels - Array of label names
  * @returns {boolean} True if the email has an Unbundled label
  */
-const checkEmailUnbundledLabel = labels => 
-  labels.some(label => label.indexOf(CSS_CLASSES.UNBUNDLED_PARENT_LABEL) >= 0);
+const checkEmailUnbundledLabel = (labels) =>
+  labels.some((label) => label.indexOf(CSS_CLASSES.UNBUNDLED_PARENT_LABEL) >= 0);
 
 /**
  * Gets the read status of an email
  * @param {Element} emailEl - The email DOM element
  * @returns {boolean} True if the email is read
  */
-const getReadStatus = emailEl => emailEl.className.indexOf('zE') < 0;
+const getReadStatus = (emailEl) => emailEl.className.indexOf('zE') < 0;
 
 // =============================================================================
 // DATE HANDLING FUNCTIONS
@@ -479,7 +482,7 @@ const getRawDate = (email) => {
  * @param {string} rawDate - The raw date string
  * @returns {Date|undefined} The Date object
  */
-const getDate = (rawDate) => rawDate ? new Date(rawDate) : undefined;
+const getDate = (rawDate) => (rawDate ? new Date(rawDate) : undefined);
 
 /**
  * Builds a human-readable date label based on the date
@@ -488,9 +491,9 @@ const getDate = (rawDate) => rawDate ? new Date(rawDate) : undefined;
  */
 const buildDateLabel = (date) => {
   if (!date) return undefined;
-  
+
   const now = new Date();
-  
+
   if (now.getFullYear() === date.getFullYear()) {
     if (now.getMonth() === date.getMonth()) {
       if (now.getDate() === date.getDate()) return DATE_LABELS.TODAY;
@@ -499,9 +502,9 @@ const buildDateLabel = (date) => {
     }
     return MONTHS[date.getMonth()];
   }
-  
+
   if (now.getFullYear() - 1 === date.getFullYear()) return DATE_LABELS.LAST_YEAR;
-  
+
   return date.getFullYear().toString();
 };
 
@@ -520,11 +523,11 @@ const addDateLabel = (email, label) => {
   // Create new date label
   const timeRow = document.createElement('div');
   timeRow.classList.add('time-row');
-  
+
   const time = document.createElement('div');
   time.className = 'time';
   time.innerText = label;
-  
+
   timeRow.appendChild(time);
   email.parentElement.insertBefore(timeRow, email);
 };
@@ -533,7 +536,7 @@ const addDateLabel = (email, label) => {
  * Cleans up redundant or empty date labels
  */
 const cleanupDateLabels = () => {
-  document.querySelectorAll('.time-row').forEach(row => {
+  document.querySelectorAll('.time-row').forEach((row) => {
     // Delete any back to back date labels
     if (row.nextSibling && row.nextSibling.className === 'time-row') {
       row.remove();
@@ -612,7 +615,7 @@ const removeClassFromBundle = (label, klass) => {
 const addCountToBundle = (label, count) => {
   const bundleLabel = document.querySelector(`div[bundleLabel="${label}"] .label-link`);
   if (!bundleLabel) return;
-  
+
   const replacementHTML = `<span>${label}</span><span class="bundle-count">(${count})</span>`;
   if (bundleLabel.innerHTML !== replacementHTML) {
     bundleLabel.innerHTML = replacementHTML;
@@ -627,23 +630,23 @@ const addCountToBundle = (label, count) => {
 const addSendersToBundle = (label, senders) => {
   const bundleSenders = document.querySelector(`div[bundleLabel="${label}"] .bundle-senders`);
   if (!bundleSenders) return;
-  
+
   // Get unique senders, prioritizing unread status
   const uniqueSenders = senders.reverse().filter((sender, index, self) => {
-    if (self.findIndex(s => s.name === sender.name && s.isUnread === sender.isUnread) === index) {
+    if (self.findIndex((s) => s.name === sender.name && s.isUnread === sender.isUnread) === index) {
       // If this sender appears with unread status elsewhere, skip the read version
-      if (!sender.isUnread && self.findIndex(s => s.name === sender.name && s.isUnread) >= 0) {
+      if (!sender.isUnread && self.findIndex((s) => s.name === sender.name && s.isUnread) >= 0) {
         return false;
       }
       return true;
     }
     return false;
   });
-  
+
   const replacementHTML = uniqueSenders
-    .map(sender => `<span class="${sender.isUnread ? 'strong' : ''}">${sender.name}</span>`)
+    .map((sender) => `<span class="${sender.isUnread ? 'strong' : ''}">${sender.name}</span>`)
     .join(', ');
-    
+
   if (bundleSenders.innerHTML !== replacementHTML) {
     bundleSenders.innerHTML = replacementHTML;
   }
@@ -703,17 +706,18 @@ const getBundleTitleColorForLabel = (email, label) => {
  * @param {string} label - The category label
  * @returns {string} The color value
  */
-const getCategoryColor = label => ({
-  Updates: 'rgb(255, 104, 57)',
-  Promotions: 'rgb(0, 188, 212)',
-  Forums: 'rgb(63, 81, 181)',
-  Social: 'rgb(219, 68, 55)',
-  Travel: 'rgb(156, 39, 176)',
-  Trips: 'rgb(156, 39, 176)',
-  Finance: 'rgb(103, 159, 56)',
-  Orders: 'rgb(121, 85, 72)',
-  Purchases: 'rgb(121, 85, 72)',
-}[label] || '#616161');
+const getCategoryColor = (label) =>
+  ({
+    Updates: 'rgb(255, 104, 57)',
+    Promotions: 'rgb(0, 188, 212)',
+    Forums: 'rgb(63, 81, 181)',
+    Social: 'rgb(219, 68, 55)',
+    Travel: 'rgb(156, 39, 176)',
+    Trips: 'rgb(156, 39, 176)',
+    Finance: 'rgb(103, 159, 56)',
+    Orders: 'rgb(121, 85, 72)',
+    Purchases: 'rgb(121, 85, 72)',
+  })[label] || '#616161';
 
 /**
  * Builds a bundle wrapper element for a label
@@ -724,8 +728,8 @@ const getCategoryColor = label => ({
 const buildBundleWrapper = (email, label, hasImportantMarkers) => {
   const importantMarkerClass = hasImportantMarkers ? '' : 'hide-important-markers';
   const bundleImage = getBundleImageForLabel(label);
-  const bundleTitleColor = bundleImage.match(/custom-cluster/) && 
-                          getBundleTitleColorForLabel(email, label);
+  const bundleTitleColor =
+    bundleImage.match(/custom-cluster/) && getBundleTitleColorForLabel(email, label);
   const styleColor = bundleTitleColor || getCategoryColor(label);
   const style = `-webkit-mask: url(${bundleImage}) 0 0/100% 100%; background-color: ${styleColor};`;
 
@@ -744,7 +748,7 @@ const buildBundleWrapper = (email, label, hasImportantMarkers) => {
   addClassToEmail(bundleWrapper, CSS_CLASSES.BUNDLE_WRAPPER);
 
   // Add click handler to navigate to the bundle
-  bundleWrapper.onclick = () => location.href = `#search/in%3Ainbox+label%3A${fixLabel(label)}`;
+  bundleWrapper.onclick = () => (location.href = `#search/in%3Ainbox+label%3A${fixLabel(label)}`);
 
   // Insert the bundle wrapper
   if (email && email.parentNode) {
@@ -824,7 +828,7 @@ const addEventAttachment = (email) => {
   let title = 'Calendar Event';
   let time = '';
   const titleNode = select.eventTitle(email);
-  
+
   if (titleNode) {
     const titleFullText = titleNode.innerText;
     const matches = Array.from(titleFullText.matchAll(/[^:]*: ([^@]*)@(.*)/g))[0];
@@ -887,7 +891,7 @@ const addEventAttachment = (email) => {
  */
 const reloadOptions = () => {
   // Get options from Chrome storage
-  chrome.runtime.sendMessage({ method: 'getOptions' }, function(ops) {
+  chrome.runtime.sendMessage({ method: 'getOptions' }, function (ops) {
     options = ops;
   });
 
@@ -897,10 +901,10 @@ const reloadOptions = () => {
   } else if (options.showAvatar === 'disabled') {
     removeClassFromBody(CSS_CLASSES.AVATAR_OPTION);
     // Remove avatar elements
-    document.querySelectorAll('.' + CSS_CLASSES.AVATAR_EMAIL)
-      .forEach(avatarEl => avatarEl.classList.remove(CSS_CLASSES.AVATAR_EMAIL));
-    document.querySelectorAll('.' + CSS_CLASSES.AVATAR)
-      .forEach(avatarEl => avatarEl.remove());
+    document
+      .querySelectorAll('.' + CSS_CLASSES.AVATAR_EMAIL)
+      .forEach((avatarEl) => avatarEl.classList.remove(CSS_CLASSES.AVATAR_EMAIL));
+    document.querySelectorAll('.' + CSS_CLASSES.AVATAR).forEach((avatarEl) => avatarEl.remove());
   }
 
   // Apply priority inbox options
@@ -916,11 +920,13 @@ const reloadOptions = () => {
   } else if (options.emailBundling === 'disabled') {
     removeClassFromBody(CSS_CLASSES.BUNDLING_OPTION);
     // Unbundle emails
-    document.querySelectorAll('.' + CSS_CLASSES.BUNDLED_EMAIL)
-      .forEach(emailEl => emailEl.classList.remove(CSS_CLASSES.BUNDLED_EMAIL));
+    document
+      .querySelectorAll('.' + CSS_CLASSES.BUNDLED_EMAIL)
+      .forEach((emailEl) => emailEl.classList.remove(CSS_CLASSES.BUNDLED_EMAIL));
     // Remove bundle wrapper rows
-    document.querySelectorAll('.' + CSS_CLASSES.BUNDLE_WRAPPER)
-      .forEach(bundleEl => bundleEl.remove());
+    document
+      .querySelectorAll('.' + CSS_CLASSES.BUNDLE_WRAPPER)
+      .forEach((bundleEl) => bundleEl.remove());
   }
 };
 
@@ -934,15 +940,14 @@ const reloadOptions = () => {
  * @returns {string[]} Array of label names
  */
 const getLabels = (email) => {
-  return Array.from(select.emailLabels(email))
-    .map(el => el.attributes.title?.value || '');
+  return Array.from(select.emailLabels(email)).map((el) => el.attributes.title?.value || '');
 };
 
 /**
  * Gets all tabs from the UI
  * @returns {string[]} Array of tab names
  */
-const getTabs = () => Array.from(select.tabs()).map(el => el.innerText);
+const getTabs = () => Array.from(select.tabs()).map((el) => el.innerText);
 
 /**
  * Processes all emails in the current view
@@ -957,86 +962,93 @@ const getEmails = () => {
   const allLabels = new Set();
   const tabs = getTabs();
 
-  let currentTab = tabs.length && select.currentTab();
+  const currentTab = tabs.length && select.currentTab();
   let prevTimeStamp = null;
   labelStats = {};
 
   // Add or remove bundle page class based on current view
-  isInBundleFlag ? 
-    addClassToBody(CSS_CLASSES.BUNDLE_PAGE) : 
-    removeClassFromBody(CSS_CLASSES.BUNDLE_PAGE);
+  isInBundleFlag
+    ? addClassToBody(CSS_CLASSES.BUNDLE_PAGE)
+    : removeClassFromBody(CSS_CLASSES.BUNDLE_PAGE);
 
   // Process emails from last to first (bottom to top in UI)
   for (let i = emails.length - 1; i >= 0; i--) {
     const email = emails[i];
     const info = {
       emailEl: email,
-      
+
       // Email classification
       isReminder: isReminder(email, myEmailAddress),
       reminderAlreadyProcessed: () => checkEmailClass(email, CSS_CLASSES.REMINDER_EMAIL),
-      
+
       // Date information
       dateString: getRawDate(email),
       date: null, // Will be set below
       dateLabel: null, // Will be set below
-      
+
       // Email status
       isSnooze: false, // Will be set below
       isStarred: isStarred(email),
       isCalendarEvent: isCalendarEvent(email),
-      
+
       // Labels
       labels: getLabels(email),
-      
+
       // Unbundled status
       unbundledAlreadyProcessed: () => checkEmailClass(email, CSS_CLASSES.UNBUNDLED_EMAIL),
       isUnbundled: false, // Will be set below
-      
+
       // Read status
       isUnread: !getReadStatus(email),
-      
+
       // Subject
       subjectEl: select.emailTitleNode(email),
       subject: '', // Will be set below
-      
+
       // Processing status flags
       isBundleEmail: () => checkEmailClass(email, CSS_CLASSES.BUNDLED_EMAIL),
       isBundleWrapper: () => checkEmailClass(email, CSS_CLASSES.BUNDLE_WRAPPER),
       avatarAlreadyProcessed: () => checkEmailClass(email, CSS_CLASSES.AVATAR_EMAIL),
-      bundleAlreadyProcessed: () => checkEmailClass(email, CSS_CLASSES.BUNDLED_EMAIL) || 
-                                   checkEmailClass(email, CSS_CLASSES.BUNDLE_WRAPPER),
+      bundleAlreadyProcessed: () =>
+        checkEmailClass(email, CSS_CLASSES.BUNDLED_EMAIL) ||
+        checkEmailClass(email, CSS_CLASSES.BUNDLE_WRAPPER),
       calendarAlreadyProcessed: () => checkEmailClass(email, CSS_CLASSES.CALENDAR_EMAIL),
     };
-    
+
     // Set date information
     info.date = getDate(info.dateString);
     info.dateLabel = buildDateLabel(info.date);
-    
+
     // Check if email is snoozed
     info.isSnooze = isSnoozed(email, info.date, prevTimeStamp);
-    
+
     // Only update prevTimeStamp if not snoozed
     if (!info.isSnooze && info.date) {
       prevTimeStamp = info.date;
     }
-    
+
     // Add labels to the set of all labels
-    info.labels.forEach(l => allLabels.add(l));
-    
+    info.labels.forEach((l) => allLabels.add(l));
+
     // Check for Unbundled parent label
     info.isUnbundled = checkEmailUnbundledLabel(info.labels);
-    
+
     // Process unbundled emails
-    if ((isInInboxFlag || isInBundleFlag) && info.isUnbundled && !info.unbundledAlreadyProcessed()) {
+    if (
+      (isInInboxFlag || isInBundleFlag) &&
+      info.isUnbundled &&
+      !info.unbundledAlreadyProcessed()
+    ) {
       addClassToEmail(email, CSS_CLASSES.UNBUNDLED_EMAIL);
-      
+
       // Process labels for unbundled emails
-      select.emailAllLabels(info.emailEl).forEach(labelEl => {
+      select.emailAllLabels(info.emailEl).forEach((labelEl) => {
         if (select.labelTitle(labelEl).title.indexOf(CSS_CLASSES.UNBUNDLED_PARENT_LABEL) >= 0) {
           // Remove 'Unbundled/' from display in the UI
-          select.labelInnerText(labelEl).innerText = 
-            labelEl.innerText.replace(CSS_CLASSES.UNBUNDLED_PARENT_LABEL + '/', '');
+          select.labelInnerText(labelEl).innerText = labelEl.innerText.replace(
+            CSS_CLASSES.UNBUNDLED_PARENT_LABEL + '/',
+            '',
+          );
         } else {
           // Hide labels that aren't nested under UNBUNDLED_PARENT_LABEL
           labelEl.hidden = true;
@@ -1046,37 +1058,39 @@ const getEmails = () => {
 
     // Hide tab labels from emails
     if (currentTab) {
-      select.emailAllLabels(info.emailEl).forEach(labelEl => {
+      select.emailAllLabels(info.emailEl).forEach((labelEl) => {
         if (labelEl.innerText === currentTab.innerText) {
           labelEl.hidden = true;
         }
       });
     }
-    
+
     // Set subject
     info.subject = info.subjectEl ? info.subjectEl.innerText.trim() : '';
-    
+
     // Collect statistics for labels
     if (info.labels.length) {
       const participants = Array.from(select.emailParticipants(email));
       const firstParticipant = participants[0]?.getAttribute('name') || '';
-      
-      info.labels.forEach(label => {
+
+      info.labels.forEach((label) => {
         if (!(label in labelStats)) {
           labelStats[label] = {
             title: label,
             count: 1,
-            senders: [{
-              name: firstParticipant,
-              isUnread: info.isUnread
-            }],
-            containsUnread: info.isUnread
+            senders: [
+              {
+                name: firstParticipant,
+                isUnread: info.isUnread,
+              },
+            ],
+            containsUnread: info.isUnread,
           };
         } else {
           labelStats[label].count++;
           labelStats[label].senders.push({
             name: firstParticipant,
-            isUnread: info.isUnread
+            isUnread: info.isUnread,
           });
           if (info.isUnread) {
             labelStats[label].containsUnread = true;
@@ -1084,7 +1098,7 @@ const getEmails = () => {
         }
       });
     }
-    
+
     processedEmails[i] = info;
   }
 
@@ -1092,14 +1106,14 @@ const getEmails = () => {
   for (const label in labelStats) {
     // Set message count for each bundle row
     addCountToBundle(label, labelStats[label].count);
-    
+
     // Set list of senders for each bundle row
     addSendersToBundle(label, labelStats[label].senders);
-    
+
     // Set bold title class for any bundle containing an unread email
-    labelStats[label].containsUnread ? 
-      addClassToBundle(label, CSS_CLASSES.UNREAD_BUNDLE) : 
-      removeClassFromBundle(label, CSS_CLASSES.UNREAD_BUNDLE);
+    labelStats[label].containsUnread
+      ? addClassToBundle(label, CSS_CLASSES.UNREAD_BUNDLE)
+      : removeClassFromBundle(label, CSS_CLASSES.UNREAD_BUNDLE);
   }
 
   return [processedEmails, allLabels];
@@ -1111,10 +1125,10 @@ const getEmails = () => {
 const updateReminders = () => {
   // Reload user options
   reloadOptions();
-  
+
   // Get processed emails and all labels
   const [emails, allLabels] = getEmails();
-  
+
   // Get user email and UI state
   const myEmail = getMyEmailAddress();
   let lastLabel = null;
@@ -1124,7 +1138,7 @@ const updateReminders = () => {
 
   // Clean up date labels
   cleanupDateLabels();
-  
+
   // Get current bundle state
   const emailBundles = getBundledLabels();
 
@@ -1137,41 +1151,46 @@ const updateReminders = () => {
       // For emails with just "Reminder" as subject, clean up the display
       if (emailInfo.subject.toLowerCase() === 'reminder') {
         emailInfo.subjectEl.outerHTML = '';
-        select.emailMiscPart3(emailEl).forEach(node => node.outerHTML = '');
-        select.emailMiscPart1(emailEl).forEach(node => node.style.color = '#202124');
+        select.emailMiscPart3(emailEl).forEach((node) => (node.outerHTML = ''));
+        select.emailMiscPart1(emailEl).forEach((node) => (node.style.color = '#202124'));
       }
-      
+
       // Set the snippet text to "Reminder"
-      select.emailMiscPart2(emailEl).forEach(node => { node.innerHTML = 'Reminder'; });
+      select.emailMiscPart2(emailEl).forEach((node) => {
+        node.innerHTML = 'Reminder';
+      });
 
       // Add avatar for reminders
       const avatarWrapperEl = select.emailAvatarWrapper(emailEl);
-      if (avatarWrapperEl && avatarWrapperEl.getElementsByClassName(CSS_CLASSES.AVATAR).length === 0) {
+      if (
+        avatarWrapperEl &&
+        avatarWrapperEl.getElementsByClassName(CSS_CLASSES.AVATAR).length === 0
+      ) {
         const avatarElement = document.createElement('div');
         avatarElement.className = CSS_CLASSES.AVATAR;
         avatarWrapperEl.appendChild(avatarElement);
       }
-      
+
       // Mark as processed
       addClassToEmail(emailEl, CSS_CLASSES.REMINDER_EMAIL);
-    } 
+    }
     // Process avatars for non-reminders
     else if (
-      options.showAvatar === 'enabled' && 
-      !emailInfo.reminderAlreadyProcessed() && 
-      !emailInfo.avatarAlreadyProcessed() && 
+      options.showAvatar === 'enabled' &&
+      !emailInfo.reminderAlreadyProcessed() &&
+      !emailInfo.avatarAlreadyProcessed() &&
       !emailInfo.bundleAlreadyProcessed()
     ) {
-      let participants = Array.from(select.emailParticipants(emailEl));
+      const participants = Array.from(select.emailParticipants(emailEl));
       if (!participants.length) continue; // Skip emails without participants (e.g., drafts)
-      
+
       let firstParticipant = participants[0];
 
       // Prefer participants other than the current user
       const excludingMe = participants.filter(
-        node => node.getAttribute('email') !== myEmail && node.getAttribute('name')
+        (node) => node.getAttribute('email') !== myEmail && node.getAttribute('name'),
       );
-      
+
       if (excludingMe.length > 0) {
         firstParticipant = excludingMe[0];
       }
@@ -1189,14 +1208,12 @@ const updateReminders = () => {
         // Set background color based on first letter
         if (firstLetterCode >= 65 && firstLetterCode <= 90) {
           const baseColor = '#' + NAME_COLORS[firstLetterCode - 65];
-          
+
           // Force background color, even in dark mode
           avatarElement.style.setProperty('background-color', baseColor, 'important');
-          
+
           // Ensure text is white
           avatarElement.style.color = '#ffffff';
-          
-
         } else {
           avatarElement.style.background = '#000000';
           // Some unicode characters need special handling
@@ -1206,22 +1223,24 @@ const updateReminders = () => {
 
         avatarElement.innerText = firstLetter;
         targetElement.appendChild(avatarElement);
-        
+
         // Try to fetch BIMI brand logo asynchronously
         const email = firstParticipant.getAttribute('email');
         if (email) {
           const domain = extractDomain(email);
-          
+
           if (domain) {
             // Try to fetch brand logo (BIMI)
-            fetchBrandLogo(domain).then(brandLogoUrl => {
-              if (brandLogoUrl) {
-                // Replace letter avatar with brand logo
-                replaceAvatarWithWeb(targetElement, brandLogoUrl, name);
-              }
-            }).catch(error => {
-              // Silently handle errors
-            });
+            fetchBrandLogo(domain)
+              .then((brandLogoUrl) => {
+                if (brandLogoUrl) {
+                  // Replace letter avatar with brand logo
+                  replaceAvatarWithWeb(targetElement, brandLogoUrl, name);
+                }
+              })
+              .catch(() => {
+                // Silently handle errors
+              });
           }
         }
       }
@@ -1238,11 +1257,11 @@ const updateReminders = () => {
 
     // Handle date labels
     let label = emailInfo.dateLabel;
-    
+
     // Special handling for snoozed emails
     if (emailInfo.isSnooze) {
       // If this is the first email, assume Today, otherwise use previous label
-      label = (lastLabel == null) ? DATE_LABELS.TODAY : lastLabel;
+      label = lastLabel == null ? DATE_LABELS.TODAY : lastLabel;
     }
 
     // Add date label if it's a new label
@@ -1260,14 +1279,14 @@ const updateReminders = () => {
       }
 
       // Determine which labels should be bundled
-      let labelsToBundle = [];
+      const labelsToBundle = [];
       if (!options.bundleOne) {
         // Count emails per label to find labels with multiple emails
-        let labelCounts = emails.reduce((counts, email) => {
-          email.labels.forEach(label => counts[label] = (counts[label] || 0) + 1);
+        const labelCounts = emails.reduce((counts, email) => {
+          email.labels.forEach((label) => (counts[label] = (counts[label] || 0) + 1));
           return counts;
         }, {});
-        
+
         // Only bundle labels with more than one email
         for (const label in labelCounts) {
           if (labelCounts[label] > 1) {
@@ -1277,25 +1296,24 @@ const updateReminders = () => {
       }
 
       // Filter out tab labels
-      let labels = emailInfo.labels.filter(x => !tabs.includes(x));
-      
+      let labels = emailInfo.labels.filter((x) => !tabs.includes(x));
+
       // If bundleOne is disabled, only bundle labels with multiple emails
       if (!options.bundleOne) {
-        labels = labelsToBundle.length ? 
-          labels.filter(x => labelsToBundle.includes(x)) : [];
+        labels = labelsToBundle.length ? labels.filter((x) => labelsToBundle.includes(x)) : [];
       }
 
       // Bundle eligible emails
       if (
-        isInInboxFlag && 
-        !emailInfo.isStarred && 
-        labels.length && 
-        !emailInfo.isUnbundled && 
+        isInInboxFlag &&
+        !emailInfo.isStarred &&
+        labels.length &&
+        !emailInfo.isUnbundled &&
         !emailInfo.bundleAlreadyProcessed()
       ) {
-        labels.forEach(label => {
+        labels.forEach((label) => {
           addClassToEmail(emailEl, CSS_CLASSES.BUNDLED_EMAIL);
-          
+
           // Hide bundled emails with CSS
           if (!hiddenEmailIds.includes(emailEl.id)) {
             createStyleNodeWithEmailId(emailEl.id);
@@ -1307,13 +1325,9 @@ const updateReminders = () => {
             emailBundles[label] = true;
           }
         });
-      } 
+      }
       // Show previously hidden emails that are no longer bundled
-      else if (
-        !emailInfo.isUnbundled && 
-        !labels.length && 
-        hiddenEmailIds.includes(emailEl.id)
-      ) {
+      else if (!emailInfo.isUnbundled && !labels.length && hiddenEmailIds.includes(emailEl.id)) {
         removeStyleNodeWithEmailId(emailEl.id);
       }
     }
@@ -1329,25 +1343,25 @@ const updateReminders = () => {
  */
 const setupMenuNodes = () => {
   const sidebarSelector = '.wT .byl'; // Parent of the menu rows
-  
+
   const watchSidebar = () => {
     const sidebar = document.querySelector(sidebarSelector);
     if (!sidebar) return;
-    
+
     insertDoneMenuItem();
-    
+
     // Map menu items to their selectors
     [
-      { label: 'inbox',     selector: '.aHS-bnt' },
-      { label: 'snoozed',   selector: '.aHS-bu1' },
-      { label: 'allmail',   selector: '.aHS-aHO' },
-      { label: 'drafts',    selector: '.aHS-bnq' },
-      { label: 'sent',      selector: '.aHS-bnu' },
-      { label: 'spam',      selector: '.aHS-bnv' },
-      { label: 'trash',     selector: '.aHS-bnx' },
-      { label: 'starred',   selector: '.aHS-bnw' },
+      { label: 'inbox', selector: '.aHS-bnt' },
+      { label: 'snoozed', selector: '.aHS-bu1' },
+      { label: 'allmail', selector: '.aHS-aHO' },
+      { label: 'drafts', selector: '.aHS-bnq' },
+      { label: 'sent', selector: '.aHS-bnu' },
+      { label: 'spam', selector: '.aHS-bnv' },
+      { label: 'trash', selector: '.aHS-bnx' },
+      { label: 'starred', selector: '.aHS-bnw' },
       { label: 'important', selector: '.aHS-bns' },
-      { label: 'chats',     selector: '.aHS-aHP' },
+      { label: 'chats', selector: '.aHS-aHP' },
     ].forEach(({ label, selector }) => {
       const node = queryParentSelector(document.querySelector(selector), '.aim');
       if (node) menuNodes[label] = node;
@@ -1368,7 +1382,7 @@ const setupMenuNodes = () => {
 const insertDoneMenuItem = () => {
   // Prevent duplicate Done menu item
   if (document.querySelector('.TO.inbox-reborn-done')) return;
-  
+
   const snoozedTO = document.querySelector('.aHS-bu1')?.closest('.TO');
   if (!snoozedTO) return;
 
@@ -1381,7 +1395,8 @@ const insertDoneMenuItem = () => {
   // Fix icon
   const icon = doneTO.querySelector('.qj');
   if (icon) {
-    icon.style.backgroundImage = "url('chrome-extension://__MSG_@@extension_id__/images/ic_done_clr_24dp_r4_2x.png')";
+    icon.style.backgroundImage =
+      "url('chrome-extension://__MSG_@@extension_id__/images/ic_done_clr_24dp_r4_2x.png')";
   }
 
   // Fix label and link
@@ -1410,7 +1425,7 @@ const insertDoneMenuItem = () => {
     link.style.height = '100%';
     link.style.zIndex = '2';
     link.style.background = 'none';
-    link.onclick = function(e) {
+    link.onclick = function (e) {
       e.preventDefault();
       window.location.hash = '#archive';
     };
@@ -1418,7 +1433,7 @@ const insertDoneMenuItem = () => {
   }
 
   // Make the whole row clickable
-  doneTO.onclick = function(e) {
+  doneTO.onclick = function (e) {
     if (e.target.tagName.toLowerCase() !== 'a') {
       window.location.hash = '#archive';
     }
@@ -1431,7 +1446,7 @@ const insertDoneMenuItem = () => {
   function updateDoneHighlight() {
     const doneMenu = document.querySelector('.TO.inbox-reborn-done');
     if (!doneMenu) return;
-    
+
     if (window.location.hash === '#archive') {
       doneMenu.classList.add('nZ');
       snoozedTO.classList.remove('nZ');
@@ -1439,7 +1454,7 @@ const insertDoneMenuItem = () => {
       doneMenu.classList.remove('nZ');
     }
   }
-  
+
   window.addEventListener('hashchange', updateDoneHighlight);
   updateDoneHighlight();
 };
@@ -1455,28 +1470,26 @@ const reorderMenuItems = () => {
     '.aHS-bnx', // Trash
     '.aHS-bnv', // Spam
   ];
-  
+
   const parent = select.menuParent();
   const refer = select.menuRefer();
 
   function tryReorder() {
     // Find all the menu nodes in the desired order
-    const nodes = desiredOrder.map(sel => 
-      document.querySelector(sel)?.closest('.TO')
-    );
-    
-    if (nodes.some(n => !n) || !parent || !refer) {
+    const nodes = desiredOrder.map((sel) => document.querySelector(sel)?.closest('.TO'));
+
+    if (nodes.some((n) => !n) || !parent || !refer) {
       setTimeout(tryReorder, 250);
       return;
     }
-    
+
     // Remove from current position
-    nodes.forEach(node => parent.contains(node) && parent.removeChild(node));
-    
+    nodes.forEach((node) => parent.contains(node) && parent.removeChild(node));
+
     // Insert in the new order before the reference node
-    nodes.forEach(node => parent.insertBefore(node, refer));
+    nodes.forEach((node) => parent.insertBefore(node, refer));
   }
-  
+
   tryReorder();
 };
 
@@ -1489,7 +1502,7 @@ const reorderMenuItems = () => {
  */
 const handleHashChange = () => {
   let hash = window.location.hash;
-  
+
   if (isInBundle()) {
     hash = '#inbox';
   } else {
@@ -1499,20 +1512,20 @@ const handleHashChange = () => {
     if (hash.startsWith('#category/forums')) hash = '#forums';
     if (hash.startsWith('#category/promotions')) hash = '#promotions';
     if (hash.startsWith('#settings/labels')) hash = '#labels';
-    
+
     // Handle user-created/dynamic labels
     if (hash.startsWith('#label/')) {
       // Get the header element and Gmail link node
       const headerElement = select.headerElement();
       const titleNode = select.titleNode();
-      
+
       // Extract and decode the full label path (e.g., "Software/Chess")
       const raw = hash.slice('#label/'.length);
       const labelName = decodeURIComponent(raw.replace(/\+/g, ' '));
-      
+
       // Extract only the last part of the label path (the "leaf" label)
       const leafLabel = labelName.split('/').pop().trim();
-      
+
       if (headerElement && titleNode && titleNode.setAttribute) {
         headerElement.setAttribute('pageTitle', 'label');
         // Show just the last sub-label in the header
@@ -1523,17 +1536,17 @@ const handleHashChange = () => {
       }
       return; // Skip the rest of the logic for label pages
     }
-    
+
     // Remove label-title attribute if not on a label page
     const titleNode = select.titleNode();
     if (titleNode && titleNode.removeAttribute) {
       titleNode.removeAttribute('data-label-title');
       titleNode.removeAttribute('title');
     }
-    
+
     hash = hash.split('/')[0].split('?')[0];
   }
-  
+
   const headerElement = select.headerElement();
   const titleNode = select.titleNode();
 
@@ -1547,11 +1560,12 @@ const handleHashChange = () => {
  * Fixes label colors to ensure they're applied with !important
  */
 const fixLabelColors = () => {
-  [...document.querySelectorAll('.qj.aEe')].forEach(el => {
-    let elStyle = el.getAttribute('style');
+  [...document.querySelectorAll('.qj.aEe')].forEach((el) => {
+    const elStyle = el.getAttribute('style');
     if (elStyle) {
-      el.setAttribute('style', 
-        elStyle.replace(/(background-color:.*(?<!important));/g, '$1 !important;')
+      el.setAttribute(
+        'style',
+        elStyle.replace(/(background-color:.*(?<!important));/g, '$1 !important;'),
       );
     }
   });
@@ -1561,17 +1575,17 @@ const fixLabelColors = () => {
  * Sets up an observer to watch for label color changes
  */
 const watchLabelColorChanges = () => {
-  const LABEL_CONTAINER_SELECTOR = ".aAw.FgKVne ~ .yJ";
+  const LABEL_CONTAINER_SELECTOR = '.aAw.FgKVne ~ .yJ';
   const labelBaseNode = document.querySelector(LABEL_CONTAINER_SELECTOR);
-  
+
   if (!labelBaseNode) return;
-  
+
   const observer = new MutationObserver(() => {
     observer.disconnect();
     fixLabelColors();
     observer.observe(labelBaseNode, { attributes: true, childList: true, subtree: true });
   });
-  
+
   fixLabelColors();
   observer.observe(labelBaseNode, { attributes: true, childList: true, subtree: true });
 };
@@ -1581,14 +1595,14 @@ const watchLabelColorChanges = () => {
  */
 const addFloatingComposeButton = () => {
   if (document.querySelector('.floating-compose')) return;
-  
+
   const floatingComposeButton = document.createElement('div');
   floatingComposeButton.className = 'floating-compose';
-  floatingComposeButton.addEventListener('click', function() {
+  floatingComposeButton.addEventListener('click', function () {
     const composeButton = select.composeButton();
     composeButton?.click();
   });
-  
+
   document.body.appendChild(floatingComposeButton);
 };
 
@@ -1598,14 +1612,14 @@ const addFloatingComposeButton = () => {
 const addReminderButton = () => {
   const addReminder = document.createElement('div');
   addReminder.className = 'add-reminder';
-  
-  addReminder.addEventListener('click', function() {
+
+  addReminder.addEventListener('click', function () {
     const myEmail = getMyEmailAddress();
     const composeButton = select.composeButton();
     composeButton?.click();
 
     // Wait for compose window to open
-    waitForElement('input[peoplekit-id="BbVjBd"]', to => {
+    waitForElement('input[peoplekit-id="BbVjBd"]', (to) => {
       const title = select.messageSubjectBox();
       const body = select.messageBody();
       const from = select.messageFrom();
@@ -1616,7 +1630,7 @@ const addReminderButton = () => {
       if (body) body.focus();
     });
   });
-  
+
   document.body.appendChild(addReminder);
 };
 
@@ -1626,7 +1640,7 @@ const addReminderButton = () => {
 const moveFloatersLeft = () => {
   const reminderButton = document.querySelector('.add-reminder');
   const composeButton = document.querySelector('.floating-compose');
-  
+
   if (reminderButton) reminderButton.classList.add('moved');
   if (composeButton) composeButton.classList.add('moved');
 };
@@ -1637,7 +1651,7 @@ const moveFloatersLeft = () => {
 const moveFloatersRight = () => {
   const reminderButton = document.querySelector('.add-reminder');
   const composeButton = document.querySelector('.floating-compose');
-  
+
   if (reminderButton) reminderButton.classList.remove('moved');
   if (composeButton) composeButton.classList.remove('moved');
 };
@@ -1648,13 +1662,13 @@ const moveFloatersRight = () => {
 const sidePanelHandler = () => {
   const sidePanel = document.querySelector('div[aria-label="Side panel"]');
   if (!sidePanel) return;
-  
+
   const sidePanelBtns = sidePanel.querySelectorAll('.bse-bvF-I.aT5-aOt-I:not(#qJTzr)'); // ignore the + btn
   const addOnsFrame = document.querySelector('.buW');
 
   // Add click handlers to side panel buttons
   for (let b = 0; b < sidePanelBtns.length; b++) {
-    sidePanelBtns[b].addEventListener('click', function() {
+    sidePanelBtns[b].addEventListener('click', function () {
       moveFloatersLeft();
       sidePanelMutationHandler();
     });
@@ -1678,9 +1692,9 @@ const sidePanelMutationHandler = () => {
   waitForElement('.buW', () => {
     const addOnsPanel = document.querySelector('.buW');
     if (!addOnsPanel) return;
-    
+
     const panelResized = new ResizeObserver((entries) => {
-      for (let entry of entries) {
+      for (const entry of entries) {
         if (entry.contentRect.width === 0) {
           moveFloatersRight();
         } else {
@@ -1688,7 +1702,7 @@ const sidePanelMutationHandler = () => {
         }
       }
     });
-    
+
     panelResized.observe(addOnsPanel);
   });
 };
@@ -1711,42 +1725,42 @@ const fetchBrandLogo = async (domain) => {
 
   // Use the exact domain from the email (don't strip subdomains)
   const emailDomain = domain;
-  
+
   // Try BIMI/VMC logo from DNS TXT records - highest quality
   try {
     // Query DNS for BIMI TXT record using default selector
     const bimiSelector = 'default._bimi';
     const bimiRecord = `${bimiSelector}.${emailDomain}`;
-    
+
     // Use multiple DNS-over-HTTPS services for better compatibility
     const dnsServices = [
       `https://dns.google/resolve?name=${bimiRecord}&type=TXT`,
       `https://cloudflare-dns.com/dns-query?name=${bimiRecord}&type=TXT`,
-      `https://doh.pub/dns-query?name=${bimiRecord}&type=TXT`
+      `https://doh.pub/dns-query?name=${bimiRecord}&type=TXT`,
     ];
-    
+
     // Try each DNS service until one works
     for (const dnsUrl of dnsServices) {
       try {
         const response = await fetch(dnsUrl, {
           method: 'GET',
           headers: {
-            'Accept': 'application/dns-json',
-            'User-Agent': navigator.userAgent
-          }
+            Accept: 'application/dns-json',
+            'User-Agent': navigator.userAgent,
+          },
         });
-        
+
         if (response.ok) {
           const dnsData = await response.json();
           if (dnsData.Answer && dnsData.Answer.length > 0) {
             // Parse the BIMI TXT record
             const txtRecord = dnsData.Answer[0].data.replace(/"/g, '');
-            
+
             // Parse for logo URL (l= parameter)
             const logoMatch = txtRecord.match(/l=([^\s;]+)/);
             if (logoMatch) {
               const logoUrl = logoMatch[1];
-              
+
               // Test if the logo loads
               const result = await testImageUrl(logoUrl);
               if (result) {
@@ -1757,20 +1771,18 @@ const fetchBrandLogo = async (domain) => {
           }
           break; // Found working service, exit loop
         }
-      } catch (serviceError) {
+      } catch {
         // Try next service
         continue;
       }
     }
-  } catch (error) {
+  } catch {
     // Silently handle errors
   }
-  
+
   // No BIMI logo available - fall back to letter avatar
   return null;
 };
-
-
 
 /**
  * Creates a web avatar element for BIMI logos
@@ -1800,14 +1812,11 @@ const replaceAvatarWithWeb = (targetElement, logoUrl, name) => {
   if (existingAvatar) {
     existingAvatar.remove();
   }
-  
+
   // Create and add web avatar
   const webAvatar = createWebAvatar(logoUrl, name);
   targetElement.appendChild(webAvatar);
-  
-
 };
-
 
 /**
  * Sets a custom favicon
@@ -1818,8 +1827,6 @@ const setFavicon = () => {
     faviconLink.href = chrome.runtime.getURL('images/favicon.png');
   }
 };
-
-
 
 // =============================================================================
 // INITIALIZATION
@@ -1832,7 +1839,6 @@ const init = () => {
   setFavicon();
   setupMenuNodes();
   reorderMenuItems();
-
 };
 
 // Initialize if document.head is available, otherwise wait for DOMContentLoaded
@@ -1850,23 +1856,23 @@ if (document.head) {
 window.addEventListener('hashchange', handleHashChange);
 
 // Set up main event listeners when DOM is loaded
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('DOMContentLoaded', function () {
   // Add reminder button
   addReminderButton();
-  
+
   // Initialize header and compose button
   waitForElement('a[aria-label="Gmail"]', handleHashChange);
   waitForElement('a[aria-label="Gmail"]', addFloatingComposeButton);
-  
+
   // Set up label color observer
-  waitForElement(".aAw.FgKVne ~ .yJ", watchLabelColorChanges);
-  
+  waitForElement('.aAw.FgKVne ~ .yJ', watchLabelColorChanges);
+
   // Set up periodic email updates
   setInterval(updateReminders, 250);
-  
+
   // Set up side panel handler
-  waitForElement('div[aria-label="Side panel"] .bse-bvF-I.aT5-aOt-I[aria-label^="Get "]', sidePanelHandler);
-  
-
+  waitForElement(
+    'div[aria-label="Side panel"] .bse-bvF-I.aT5-aOt-I[aria-label^="Get "]',
+    sidePanelHandler,
+  );
 });
-

--- a/src/script.js
+++ b/src/script.js
@@ -108,7 +108,6 @@ const avatarCache = new Map();
  */
 const CSS_CLASSES = {
   REMINDER_EMAIL: 'reminder',
-  CALENDAR_EVENT: 'calendar-event',
   CALENDAR_ATTACHMENT: 'calendar-attachment',
   BUNDLE_PAGE: 'bundle-page',
   BUNDLE_WRAPPER: 'bundle-wrapper',
@@ -121,7 +120,6 @@ const CSS_CLASSES = {
   AVATAR: 'avatar',
   AVATAR_OPTION: 'show-avatar-enabled',
   WEB_AVATAR: 'web-avatar',
-  LETTER_AVATAR: 'letter-avatar',
   STYLE_NODE_ID_PREFIX: 'hide-email-',
   PRIORITY_INBOX_OPTION: 'priority-inbox-enabled',
 };

--- a/src/style.css
+++ b/src/style.css
@@ -20,22 +20,22 @@
 :root {
   --inbox-margin-right: 7vw;
   --email-max-width: 1200px;
-  
+
   /* Color palette */
   --color-background: #f2f2f2;
-  --color-surface: #ffffff;
+  --color-surface: #fff;
   --color-text-primary: #202124;
   --color-text-secondary: #616161;
-  --color-divider: #dddddd;
-  --color-shadow: rgba(0, 0, 0, 0.24);
-  
+  --color-divider: #ddd;
+  --color-shadow: rgb(0 0 0 / 24%);
+
   /* Dark mode colors (will be applied with .dark-mode class) */
   --dark-color-background: #141414;
   --dark-color-surface: #252526;
-  --dark-color-text-primary: #ffffff;
+  --dark-color-text-primary: #fff;
   --dark-color-text-secondary: #c7c7c7;
   --dark-color-divider: #3b3b3b;
-  --dark-color-shadow: rgba(0, 0, 0, 0.44);
+  --dark-color-shadow: rgb(0 0 0 / 44%);
 }
 
 /* Let Gmail use its default colorful icons for system labels */
@@ -60,7 +60,9 @@
 
 /* Header bar */
 header {
-  box-shadow: 0 0 4px rgba(0, 0, 0, .14), 0 4px 8px rgba(0, 0, 0, .28);
+  box-shadow:
+    0 0 4px rgb(0 0 0 / 14%),
+    0 4px 8px rgb(0 0 0 / 28%);
 }
 
 /* Sidebar: hide the label email counters */
@@ -84,8 +86,9 @@ header {
 }
 
 /* Mail/Chat/Spaces sidebar hover preview */
-.apV.aJu, 
-.aBA.apV.bym { /* .bym applies hover preview styles! */
+.apV.aJu,
+.aBA.apV.bym {
+  /* .bym applies hover preview styles! */
   height: calc(100vh - 64px) !important;
   border-radius: 0 !important;
 }
@@ -104,7 +107,7 @@ header {
 .n3 > .CL > .CK,
 .aAv {
   text-shadow: none;
-  color: #616161 !important
+  color: #616161 !important;
 }
 
 /* Emails */
@@ -116,7 +119,7 @@ header {
 
 /* Set opened email width to same as email list */
 .Bs.nH.iY.bAt {
-  margin: 10px auto 10px auto !important;
+  margin: 10px auto !important;
   max-width: 1180px;
   padding: 0 10px;
 }
@@ -138,6 +141,7 @@ header {
 .D.E.G-atb {
   margin: 0 auto !important;
   width: var(--email-max-width);
+
   /* this percent effectively enforces a 3.5% (7% / 2) padding when */
   max-width: 97%;
 }
@@ -145,7 +149,10 @@ header {
 /* Add box-shadow to open email + match toolbar width */
 .nH.a98.iY {
   margin: 2px 16px 0;
-  box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0,0,0,.12), 0 2px 4px rgba(0,0,0,.24) !important
+  box-shadow:
+    0 -1px 0 #e0e0e0,
+    0 0 2px rgb(0 0 0 / 12%),
+    0 2px 4px rgb(0 0 0 / 24%) !important;
 }
 
 .aeH {
@@ -181,7 +188,7 @@ header {
 td.apU.xY {
   display: block;
   position: absolute;
-  right: 0px;
+  right: 0;
 }
 
 /* Display star (pin) on hover */
@@ -306,6 +313,7 @@ td.apU.xY .T-KT.xf::before {
     background-color: #444746 !important; /* Greyish color for light mode */
     background-image: none !important; /* Ensure no conflicting background image */
   }
+
   /* Starred */
   td.apU.xY .T-KT.xl::before {
     -webkit-mask-image: url('moz-extension://__MSG_@@extension_id__/images/keep_20dp_FFFFFF_FILL1_wght400_GRAD0_opsz20.svg') !important;
@@ -319,50 +327,62 @@ td.apU.xY .T-KT.xf::before {
     background-color: #444746 !important; /* Greyish color for light mode */
     background-image: none !important; /* Ensure no conflicting background image */
   }
+
   /* Starred - Yellow Star */
   td.apU.xY .T-KT.T-KT-Jp::before {
     background-image: url('moz-extension://__MSG_@@extension_id__/images/ic-mark-pinned-yellow-24dp-r4-2x.png') !important;
   }
+
   /* Starred - Orange Star */
   td.apU.xY .T-KT.xl::before {
     background-image: url('moz-extension://__MSG_@@extension_id__/images/ic-mark-pinned-orange-24dp-r4-2x.png') !important;
   }
+
   /* Starred - Red Star */
   td.apU.xY .T-KT.xn::before {
     background-image: url('moz-extension://__MSG_@@extension_id__/images/ic-mark-pinned-red-24dp-r4-2x.png') !important;
   }
+
   /* Starred - Purple Star */
   td.apU.xY .T-KT.xm::before {
     background-image: url('moz-extension://__MSG_@@extension_id__/images/ic-mark-pinned-purple-24dp-r4-2x.png') !important;
   }
+
   /* Starred - Blue Star */
   td.apU.xY .T-KT.xj::before {
     background-image: url('moz-extension://__MSG_@@extension_id__/images/ic-mark-pinned-blue-24dp-r4-2x.png') !important;
   }
+
   /* Starred - Green Star */
   td.apU.xY .T-KT.xk::before {
     background-image: url('moz-extension://__MSG_@@extension_id__/images/ic-mark-pinned-green-24dp-r4-2x.png') !important;
   }
+
   /* Starred - Red Bang */
   td.apU.xY .T-KT.xg::before {
     background-image: url('moz-extension://__MSG_@@extension_id__/images/cleardot.gif') !important;
   }
+
   /* Starred - Orange Guillimet */
   td.apU.xY .T-KT.xe::before {
     background-image: url('moz-extension://__MSG_@@extension_id__/images/cleardot.gif') !important;
   }
+
   /* Starred - Yellow Bang */
   td.apU.xY .T-KT.xh::before {
     background-image: url('moz-extension://__MSG_@@extension_id__/images/cleardot.gif') !important;
   }
+
   /* Starred - Green Check */
   td.apU.xY .T-KT.xd::before {
     background-image: url('moz-extension://__MSG_@@extension_id__/images/cleardot.gif') !important;
   }
+
   /* Starred - Blue Info */
   td.apU.xY .T-KT.xc::before {
     background-image: url('moz-extension://__MSG_@@extension_id__/images/cleardot.gif') !important;
   }
+
   /* Starred - Purple Question */
   td.apU.xY .T-KT.xf::before {
     background-image: url('moz-extension://__MSG_@@extension_id__/images/cleardot.gif') !important;
@@ -371,7 +391,7 @@ td.apU.xY .T-KT.xf::before {
 
 /* Unread email */
 .yO {
-  background: #FFF !important;
+  background: #fff !important;
 }
 
 /* Time */
@@ -384,12 +404,19 @@ td.apU.xY .T-KT.xf::before {
 }
 
 /* Email */
-.zA, .zA:hover {
-  box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0,0,0,.12), 0 2px 4px rgba(0,0,0,.24) !important;
-  -webkit-box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0,0,0,.12), 0 2px 4px rgba(0,0,0,.24) !important;
+.zA,
+.zA:hover {
+  box-shadow:
+    0 -1px 0 #e0e0e0,
+    0 0 2px rgb(0 0 0 / 12%),
+    0 2px 4px rgb(0 0 0 / 24%) !important;
+  -webkit-box-shadow:
+    0 -1px 0 #e0e0e0,
+    0 0 2px rgb(0 0 0 / 12%),
+    0 2px 4px rgb(0 0 0 / 24%) !important;
   z-index: inherit !important;
   padding-right: 24px;
-  background: #FFF !important;
+  background: #fff !important;
 }
 
 /* Inbox Email is Empty show Sun */
@@ -400,7 +427,7 @@ td.apU.xY .T-KT.xf::before {
   padding-top: 30px;
   height: 618px;
   width: 456px;
-  background-color: #F2F2F2;
+  background-color: #f2f2f2;
   color: transparent;
   font-size: 14px;
 }
@@ -434,7 +461,8 @@ td.apU.xY .T-KT.xf::before {
 /* Chat + Spaces: Full Screen Views */
 
 /* Spaces */
-.aBA + .bkK, .a3W + .bkK {
+.aBA + .bkK,
+.a3W + .bkK {
   margin-left: 0 !important;
 }
 
@@ -464,18 +492,17 @@ td.apU.xY .T-KT.xf::before {
 
 /* Menu item row, hover */
 .TK .TO:hover {
-  background-color: rgba(0,0,0,.05) !important;
+  background-color: rgb(0 0 0 / 5%) !important;
   cursor: pointer;
 }
 
 /* Menu item row active */
 .TK .TO:active,
-.n6 .ah9.aiu:active
-.CL:active,
+.n6 .ah9.aiu:active .CL:active,
 .TO.nZ,
 .TO.NQ,
 .TO.ol {
-  background-color: rgba(0,0,0,.05) !important;
+  background-color: rgb(0 0 0 / 5%) !important;
 }
 
 /* Left sidebar collapsed */
@@ -495,6 +522,7 @@ td.apU.xY .T-KT.xf::before {
   position: relative;
   box-sizing: border-box;
   cursor: pointer !important;
+
   /* To allow highlight/hover like other rows */
   transition: background 0.12s;
 }
@@ -528,7 +556,7 @@ body.dark-mode .TO.inbox-reborn-done::after {
 /* On hover, look like all other menu rows */
 .TO.inbox-reborn-done:hover,
 .TO.inbox-reborn-done.nZ {
-  background-color: rgba(0,0,0,.05) !important;
+  background-color: rgb(0 0 0 / 5%) !important;
 }
 
 /* Make all children take full height */
@@ -549,7 +577,8 @@ body.dark-mode .TO.inbox-reborn-done::after {
   border: none;
   box-sizing: border-box;
   position: absolute;
-  left: 0; top: 0;
+  left: 0;
+  top: 0;
   z-index: 2;
   cursor: pointer !important;
 }
@@ -580,8 +609,8 @@ body.dark-mode .TO.inbox-reborn-done::after {
 
 /* Compose email old place */
 .z0 {
-  margin: 0px !important;
-  height: 0px !important;
+  margin: 0 !important;
+  height: 0 !important;
 }
 
 /* Compose email boxes wrapper */
@@ -590,6 +619,7 @@ body.dark-mode .TO.inbox-reborn-done::after {
 }
 
 /* Compose email popup */
+
 /* Top bar */
 .nH .Hy .m {
   background: #404040 !important;
@@ -632,8 +662,11 @@ body.dark-mode .TO.inbox-reborn-done::after {
 }
 
 /* .Hn applies :hover color */
-.Hk.Hn, .Hl.Hn, .Hr.Hq, .Ha.Hb {
-  background: rgba(255,255,255,0.5) !important;
+.Hk.Hn,
+.Hl.Hn,
+.Hr.Hq,
+.Ha.Hb {
+  background: rgb(255 255 255 / 50%) !important;
 }
 
 /* Hangout chat box wrapper */
@@ -678,7 +711,7 @@ body.dark-mode .TO.inbox-reborn-done::after {
 }
 
 .wT > .n3 .byl:first-child .aim:first-child .nZ {
-  background-color: rgba(0,0,0,.05) !important;
+  background-color: rgb(0 0 0 / 5%) !important;
 }
 
 /* =============================================================================
@@ -715,7 +748,7 @@ body.dark-mode .uW2Fw-bHo .a7H {
 
 body.dark-mode .uW2Fw-bHo .a7H:focus {
   border-color: #8ab4f8 !important;
-  box-shadow: 0 0 0 2px rgba(138, 180, 248, 0.2) !important;
+  box-shadow: 0 0 0 2px rgb(138 180 248 / 20%) !important;
 }
 
 /* New Label popup placeholder text */
@@ -824,13 +857,11 @@ body.dark-mode .V3.aam.ada::-webkit-scrollbar-thumb:hover {
     scrollbar-width: thin !important;
     scrollbar-color: #141414 transparent !important;
   }
-  
+
   body.dark-mode .V3.aam.ada:hover {
     scrollbar-color: #323232 transparent !important;
   }
 }
-
-
 
 .qj {
   width: 24px !important;
@@ -872,7 +903,6 @@ body.dark-mode .V3.aam.ada::-webkit-scrollbar-thumb:hover {
     background-image: url('moz-extension://__MSG_@@extension_id__/images/star_24dp_F1C411_FILL1_wght400_GRAD0_opsz24.svg') !important;
   }
 }
-
 
 /* Important */
 .aHS-bns .qj {
@@ -952,97 +982,99 @@ body.dark-mode .V3.aam.ada::-webkit-scrollbar-thumb:hover {
 
 /* Sent */
 .aHS-bnu .qj {
-	-webkit-mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_send_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
-	mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_send_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
-	-webkit-mask-size: 24px !important;
-	mask-size: 24px !important;
-	background-color: #4C4F4D !important;
+  -webkit-mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_send_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
+  mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_send_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
+  -webkit-mask-size: 24px !important;
+  mask-size: 24px !important;
+  background-color: #4c4f4d !important;
 }
+
 /* Drafts */
 .aHS-bnq .qj {
-	-webkit-mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_drafts_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
-	mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_drafts_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
-	-webkit-mask-size: 24px !important;
-	mask-size: 24px !important;
-	background-color: #4C4F4D !important;
+  -webkit-mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_drafts_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
+  mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_drafts_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
+  -webkit-mask-size: 24px !important;
+  mask-size: 24px !important;
+  background-color: #4c4f4d !important;
 }
 
 /* All Mail */
 .aHS-aHO .qj {
-	-webkit-mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_all_mail_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
-	mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_all_mail_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
-	-webkit-mask-size: 24px !important;
-	mask-size: 24px !important;
-	background-color: #4C4F4D !important;
+  -webkit-mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_all_mail_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
+  mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_all_mail_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
+  -webkit-mask-size: 24px !important;
+  mask-size: 24px !important;
+  background-color: #4c4f4d !important;
 }
+
 /* Trash */
 .aHS-bnx .qj {
-	-webkit-mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_trash_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
-	mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_trash_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
-	-webkit-mask-size: 24px !important;
-	mask-size: 24px !important;
-	background-color: #4C4F4D !important;
+  -webkit-mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_trash_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
+  mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_trash_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
+  -webkit-mask-size: 24px !important;
+  mask-size: 24px !important;
+  background-color: #4c4f4d !important;
 }
+
 /* Spam */
 .aHS-bnv .qj {
-	-webkit-mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_spam_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
-	mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_spam_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
-	-webkit-mask-size: 24px !important;
-	mask-size: 24px !important;
-	background-color: #4C4F4D !important;
+  -webkit-mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_spam_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
+  mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_spam_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
+  -webkit-mask-size: 24px !important;
+  mask-size: 24px !important;
+  background-color: #4c4f4d !important;
 }
 
 /* Categories */
-[data-tooltip="Categories"] .aEc.aHS-bnr .qj {
-	-webkit-mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_categories_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
-	mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_categories_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
-	-webkit-mask-size: 24px !important;
-	mask-size: 24px !important;
-	background-color: #4C4F4D !important;
+[data-tooltip='Categories'] .aEc.aHS-bnr .qj {
+  -webkit-mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_categories_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
+  mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_categories_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
+  -webkit-mask-size: 24px !important;
+  mask-size: 24px !important;
+  background-color: #4c4f4d !important;
 }
 
 /* Social */
-[data-tooltip="Social"] .qj {
-	-webkit-mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_social_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
-	mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_social_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
-	-webkit-mask-size: 24px !important;
-	mask-size: 24px !important;
-	background-color: #4C4F4D !important;
+[data-tooltip='Social'] .qj {
+  -webkit-mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_social_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
+  mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_social_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
+  -webkit-mask-size: 24px !important;
+  mask-size: 24px !important;
+  background-color: #4c4f4d !important;
 }
 
 /* Updates */
-[data-tooltip="Updates"] .qj {
-	-webkit-mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_updates_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
-	mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_updates_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
-	-webkit-mask-size: 24px !important;
-	mask-size: 24px !important;
-	background-color: #4C4F4D !important;
+[data-tooltip='Updates'] .qj {
+  -webkit-mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_updates_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
+  mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_updates_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
+  -webkit-mask-size: 24px !important;
+  mask-size: 24px !important;
+  background-color: #4c4f4d !important;
 }
 
 /* Forums */
-[data-tooltip="Forums"] .qj {
-	-webkit-mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_forums_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
-	mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_forums_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
-	-webkit-mask-size: 24px !important;
-	mask-size: 24px !important;
-	background-color: #4C4F4D !important;
+[data-tooltip='Forums'] .qj {
+  -webkit-mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_forums_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
+  mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_forums_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
+  -webkit-mask-size: 24px !important;
+  mask-size: 24px !important;
+  background-color: #4c4f4d !important;
 }
 
 /* Promotions */
-[data-tooltip="Promotions"] .qj {
-	-webkit-mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_promotions_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
-	mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_promotions_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
-	-webkit-mask-size: 24px !important;
-	mask-size: 24px !important;
-	background-color: #4C4F4D !important;
+[data-tooltip='Promotions'] .qj {
+  -webkit-mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_promotions_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
+  mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_promotions_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
+  -webkit-mask-size: 24px !important;
+  mask-size: 24px !important;
+  background-color: #4c4f4d !important;
 }
 
 /* Category buttons */
-.CL.Q7::before, .CL.Wj::before {
+.CL.Q7::before,
+.CL.Wj::before {
   opacity: 0.9 !important;
 }
-
-
 
 /* Hide scrollbars globally for all browsers */
 .wT,
@@ -1063,10 +1095,12 @@ body.dark-mode .V3.aam.ada::-webkit-scrollbar-thumb:hover {
   .aHS-bnt .qj {
     background-image: url('moz-extension://__MSG_@@extension_id__/images/inbox_googblue_24dp.png') !important;
   }
+
   /* Dropdown arrow */
   .aHS-bnt .afM {
     background-image: url('moz-extension://__MSG_@@extension_id__/images/arrow_drop_down_black_20dp.png') !important;
   }
+
   /* Important */
   .aHS-bns .qj {
     -webkit-mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_label_important_20dp_FFFFFF_FILL1_wght400_GRAD0_opsz20.svg') !important;
@@ -1080,6 +1114,7 @@ body.dark-mode .V3.aam.ada::-webkit-scrollbar-thumb:hover {
     background-color: #444746 !important;
     background-image: none !important;
   }
+
   /* Chats */
   .aHS-aHP .qj {
     -webkit-mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_chat_20dp_FFFFFF_FILL1_wght400_GRAD0_opsz20.svg') !important;
@@ -1093,10 +1128,12 @@ body.dark-mode .V3.aam.ada::-webkit-scrollbar-thumb:hover {
     background-color: #444746 !important;
     background-image: none !important;
   }
+
   /* Snoozed */
   .aHS-bu1 .qj {
     background-image: url('moz-extension://__MSG_@@extension_id__/images/ic_upcoming_clr_24dp_r5_2x.png') !important;
   }
+
   /* Sent */
   .aHS-bnu .qj {
     -webkit-mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_send_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
@@ -1107,8 +1144,9 @@ body.dark-mode .V3.aam.ada::-webkit-scrollbar-thumb:hover {
     mask-repeat: no-repeat !important;
     -webkit-mask-size: 24px !important;
     mask-size: 24px !important;
-    background-color: #4C4F4D !important;
+    background-color: #4c4f4d !important;
   }
+
   /* Drafts */
   .aHS-bnq .qj {
     -webkit-mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_drafts_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
@@ -1119,8 +1157,9 @@ body.dark-mode .V3.aam.ada::-webkit-scrollbar-thumb:hover {
     mask-repeat: no-repeat !important;
     -webkit-mask-size: 24px !important;
     mask-size: 24px !important;
-    background-color: #4C4F4D !important;
+    background-color: #4c4f4d !important;
   }
+
   /* Scheduled */
   .aHS-nd .qj {
     -webkit-mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_schedule_send_20dp_FFFFFF_FILL1_wght400_GRAD0_opsz20.svg') !important;
@@ -1134,6 +1173,7 @@ body.dark-mode .V3.aam.ada::-webkit-scrollbar-thumb:hover {
     background-color: #444746 !important; /* Greyish color for light mode */
     background-image: none !important; /* Ensure no conflicting background image */
   }
+
   /* All Mail */
   .aHS-aHO .qj {
     -webkit-mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_all_mail_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
@@ -1144,8 +1184,9 @@ body.dark-mode .V3.aam.ada::-webkit-scrollbar-thumb:hover {
     mask-repeat: no-repeat !important;
     -webkit-mask-size: 24px !important;
     mask-size: 24px !important;
-    background-color: #4C4F4D !important;
+    background-color: #4c4f4d !important;
   }
+
   /* Trash */
   .aHS-bnx .qj {
     -webkit-mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_trash_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
@@ -1156,8 +1197,9 @@ body.dark-mode .V3.aam.ada::-webkit-scrollbar-thumb:hover {
     mask-repeat: no-repeat !important;
     -webkit-mask-size: 24px !important;
     mask-size: 24px !important;
-    background-color: #4C4F4D !important;
+    background-color: #4c4f4d !important;
   }
+
   /* Spam */
   .aHS-bnv .qj {
     -webkit-mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_spam_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
@@ -1168,13 +1210,14 @@ body.dark-mode .V3.aam.ada::-webkit-scrollbar-thumb:hover {
     mask-repeat: no-repeat !important;
     -webkit-mask-size: 24px !important;
     mask-size: 24px !important;
-    background-color: #4C4F4D !important;
+    background-color: #4c4f4d !important;
   }
+
   /* Category */
   .aHS-bnr .qj /*:not(.aEe)*/ {
-    /*background-image: url('moz-extension://__MSG_@@extension_id__/images/ic_custom-cluster_24px_g60_r3_2x.png') !important;*/
+    /* background-image: url('moz-extension://__MSG_@@extension_id__/images/ic_custom-cluster_24px_g60_r3_2x.png') !important; */
   }
-  
+
   /* Labels - Firefox */
   .aEe,
   .aEc.aHS-bnr .qj,
@@ -1190,7 +1233,7 @@ body.dark-mode .V3.aam.ada::-webkit-scrollbar-thumb:hover {
     mask-position: center !important;
     background-color: #444746 !important;
   }
-  
+
   /* Labels (only) - Firefox */
   .zw .aHS-bnr .qj {
     -webkit-mask-image: url('moz-extension://__MSG_@@extension_id__/images/label_important_20dp_FFFFFF_FILL1_wght400_GRAD0_opsz20.svg') !important;
@@ -1203,8 +1246,9 @@ body.dark-mode .V3.aam.ada::-webkit-scrollbar-thumb:hover {
     mask-position: center !important;
     background-color: #444746 !important;
   }
+
   /* Category icons */
-  [data-tooltip="Social"] .qj {
+  [data-tooltip='Social'] .qj {
     -webkit-mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_social_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
     mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_social_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
     -webkit-mask-position: center !important;
@@ -1213,9 +1257,10 @@ body.dark-mode .V3.aam.ada::-webkit-scrollbar-thumb:hover {
     mask-repeat: no-repeat !important;
     -webkit-mask-size: 24px !important;
     mask-size: 24px !important;
-    background-color: #4C4F4D !important;
+    background-color: #4c4f4d !important;
   }
-  [data-tooltip="Updates"] .qj {
+
+  [data-tooltip='Updates'] .qj {
     -webkit-mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_updates_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
     mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_updates_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
     -webkit-mask-position: center !important;
@@ -1224,9 +1269,10 @@ body.dark-mode .V3.aam.ada::-webkit-scrollbar-thumb:hover {
     mask-repeat: no-repeat !important;
     -webkit-mask-size: 24px !important;
     mask-size: 24px !important;
-    background-color: #4C4F4D !important;
+    background-color: #4c4f4d !important;
   }
-  [data-tooltip="Forums"] .qj {
+
+  [data-tooltip='Forums'] .qj {
     -webkit-mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_forums_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
     mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_forums_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
     -webkit-mask-position: center !important;
@@ -1235,38 +1281,39 @@ body.dark-mode .V3.aam.ada::-webkit-scrollbar-thumb:hover {
     mask-repeat: no-repeat !important;
     -webkit-mask-size: 24px !important;
     mask-size: 24px !important;
-    background-color: #4C4F4D !important;
+    background-color: #4c4f4d !important;
   }
-  [data-tooltip="Promotions"] .qj {
+
+  [data-tooltip='Promotions'] .qj {
     -webkit-mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_promotions_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
     mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_promotions_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
     -webkit-mask-size: 24px !important;
     mask-size: 24px !important;
-    background-color: #4C4F4D !important;
+    background-color: #4c4f4d !important;
   }
-  
+
   /* Categories */
-  [data-tooltip="Categories"] .aEc.aHS-bnr .qj {
+  [data-tooltip='Categories'] .aEc.aHS-bnr .qj {
     -webkit-mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_categories_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
     mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_categories_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
     -webkit-mask-size: 24px !important;
     mask-size: 24px !important;
-    background-color: #4C4F4D !important;
+    background-color: #4c4f4d !important;
     background-image: none !important;
   }
-  
+
   /* Firefox dark mode for Categories */
-  body.dark-mode [data-tooltip="Categories"] .qj {
-    background-color: #ffffff !important;
+  body.dark-mode [data-tooltip='Categories'] .qj {
+    background-color: #fff !important;
   }
-  
+
   /* Firefox dark mode override for Categories to preserve mask-image */
-  body.dark-mode [data-tooltip="Categories"] .aEc.aHS-bnr .qj {
+  body.dark-mode [data-tooltip='Categories'] .aEc.aHS-bnr .qj {
     -webkit-mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_categories_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
     mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_categories_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
     -webkit-mask-size: 24px !important;
     mask-size: 24px !important;
-    background-color: #ffffff !important;
+    background-color: #fff !important;
     background-image: none !important;
   }
 }
@@ -1346,10 +1393,10 @@ body.dark-mode .TN.bzz.aHS-bnx::after {
    MAIN MENU, SEARCH BAR AND EMAIL AREA
    ============================================================================= */
 
-/* main top bar including shadow*/
+/* main top bar including shadow */
 .gb_xd.gb_4d.gb_Fd {
   height: 56px;
-  box-shadow: 0px 5px 4px #c6c6c6;
+  box-shadow: 0 5px 4px #c6c6c6;
 }
 
 form.bas {
@@ -1361,9 +1408,9 @@ form.bas > table {
 }
 
 /* search icon */
-button.gb_ff.gb_gf  {
+button.gb_ff.gb_gf {
   margin-top: -3px;
-  margin-left: 0px;
+  margin-left: 0;
 }
 
 /* main search window */
@@ -1378,20 +1425,21 @@ input.gb_3e {
 }
 
 /* Google Apps icon & Google Account icon */
-.gb_w.gb_Xc.gb_f.gb_Af, .gb_Ea.gb_Xc.gb_qg.gb_f.gb_Af {
+.gb_w.gb_Xc.gb_f.gb_Af,
+.gb_Ea.gb_Xc.gb_qg.gb_f.gb_Af {
   margin-top: -7px;
 }
 
 /* search bar */
 .gb_mf.gb_gf {
-  margin-top: 0px;
+  margin-top: 0;
   margin-left: 30px;
   height: 36px;
 }
 
 /* colapsed main menu */
 .no {
-  background-color: #F2F2F2;
+  background-color: #f2f2f2;
 }
 
 /* main email / chat / spaces area */
@@ -1409,7 +1457,9 @@ input.gb_3e {
   max-width: var(--email-max-width) !important;
 }
 
-.aKk>tbody, .aAA, .aRz.J-KU {
+.aKk > tbody,
+.aAA,
+.aRz.J-KU {
   justify-content: center !important;
 }
 
@@ -1440,9 +1490,8 @@ input.gb_3e {
 .aKh,
 
 /* Empty inbox tab */
-.aRs
-{
-  background: #F2F2F2 !important;
+.aRs {
+  background: #f2f2f2 !important;
 }
 
 /* Quick Settings panel */
@@ -1459,6 +1508,7 @@ input.gb_3e {
 /* =============================================================================
    GMAIL TOP BAR COLOR OVERRIDES
    ============================================================================= */
+
 /**
  * Gmail Top Bar Color Overrides
  * --------------------------------
@@ -1481,109 +1531,110 @@ input.gb_3e {
 }
 
 /* Inbox */
-.w-asV.bbg.aiw[pageTitle="inbox"] {
+.w-asV.bbg.aiw[pageTitle='inbox'] {
   background-color: #4285f4;
 }
 
 /* Starred */
-.w-asV.bbg.aiw[pageTitle="starred"] {
-  background-color: #fbc02d; 
+.w-asV.bbg.aiw[pageTitle='starred'] {
+  background-color: #fbc02d;
 }
 
 /* Snoozed */
-.w-asV.bbg.aiw[pageTitle="snoozed"] {
+.w-asV.bbg.aiw[pageTitle='snoozed'] {
   background-color: #ef6c00;
 }
 
 /* Sent - teal */
-.w-asV.bbg.aiw[pageTitle="sent"] {
+.w-asV.bbg.aiw[pageTitle='sent'] {
   background-color: #009688;
 }
 
 /* Drafts */
-.w-asV.bbg.aiw[pageTitle="drafts"] {
-  background-color: #8d6e63; 
+.w-asV.bbg.aiw[pageTitle='drafts'] {
+  background-color: #8d6e63;
 }
 
 /* All Mail */
-.w-asV.bbg.aiw[pageTitle="all"] {
+.w-asV.bbg.aiw[pageTitle='all'] {
   background-color: #4285f4;
 }
 
 /* Spam */
-.w-asV.bbg.aiw[pageTitle="spam"] {
+.w-asV.bbg.aiw[pageTitle='spam'] {
   background-color: #d93025;
 }
 
 /* Trash */
-.w-asV.bbg.aiw[pageTitle="trash"] {
+.w-asV.bbg.aiw[pageTitle='trash'] {
   background-color: #5f6368;
 }
 
 /* Social */
-.w-asV.bbg.aiw[pageTitle="social"] {
+.w-asV.bbg.aiw[pageTitle='social'] {
   background-color: #009688;
 }
 
 /* Updates */
-.w-asV.bbg.aiw[pageTitle="updates"] {
+.w-asV.bbg.aiw[pageTitle='updates'] {
   background-color: #ffa600;
 }
 
 /* Forums */
-.w-asV.bbg.aiw[pageTitle="forums"] {
-  background-color: #bc5090; 
+.w-asV.bbg.aiw[pageTitle='forums'] {
+  background-color: #bc5090;
 }
 
 /* Promotions  */
-.w-asV.bbg.aiw[pageTitle="promotions"] {
-  background-color: #8bc34a; 
+.w-asV.bbg.aiw[pageTitle='promotions'] {
+  background-color: #8bc34a;
 }
 
 /* Important */
-.w-asV.bbg.aiw[pageTitle="imp"] {
+.w-asV.bbg.aiw[pageTitle='imp'] {
   background-color: #ff5722;
 }
 
 /* Scheduled */
-.w-asV.bbg.aiw[pageTitle="scheduled"] {
+.w-asV.bbg.aiw[pageTitle='scheduled'] {
   background-color: #33b679;
 }
 
 /* Manage subscriptions */
-.w-asV.bbg.aiw[pageTitle="sub"] {
-  background-color: #00acc1; 
+.w-asV.bbg.aiw[pageTitle='sub'] {
+  background-color: #00acc1;
 }
 
 /* Mange Labels */
-.w-asV.bbg.aiw[pageTitle="labels"] {
-  background-color: #5e87f5; 
+.w-asV.bbg.aiw[pageTitle='labels'] {
+  background-color: #5e87f5;
 }
 
 /* Labels Custom for users */
-.w-asV.bbg.aiw[pageTitle="label"] {
-  background-color: #5e87f5; 
+.w-asV.bbg.aiw[pageTitle='label'] {
+  background-color: #5e87f5;
 }
 
 /* Archive  */
-.w-asV.bbg.aiw[pageTitle="archive"] {
+.w-asV.bbg.aiw[pageTitle='archive'] {
   background-color: #0f9d58;
 }
 
 /* Chat */
-.w-asV.bbg.aiw[pageTitle="chat"],
-.w-asV.bbg.aiw[pageTitle="onboarding"] {
+.w-asV.bbg.aiw[pageTitle='chat'],
+.w-asV.bbg.aiw[pageTitle='onboarding'] {
   background-color: #00ac47;
 }
 
 /* Meet */
-.w-asV.bbg.aiw[pageTitle="calls"] {
+.w-asV.bbg.aiw[pageTitle='calls'] {
   background-color: #db4437;
 }
 
 /* =============================================================================
    CATEGORY & LABEL PAGE TITLES (HEADER BAR)
    ============================================================================= */
+
 /**
  * These rules display the title in the Gmail header based on the
  * `pageTitle` attribute set by handleHashChange() in JavaScript:
@@ -1592,22 +1643,27 @@ input.gb_3e {
  * • `label` — dynamic: content pulled from `data-label-title` which
  *               JS sets to the leaf (last segment) of a custom label.
  */
-.w-asV.bbg.aiw[pageTitle="social"] a[aria-label="Gmail"]::after {
+.w-asV.bbg.aiw[pageTitle='social'] a[aria-label='Gmail']::after {
   content: 'Social';
 }
-.w-asV.bbg.aiw[pageTitle="updates"] a[aria-label="Gmail"]::after {
+
+.w-asV.bbg.aiw[pageTitle='updates'] a[aria-label='Gmail']::after {
   content: 'Updates';
 }
-.w-asV.bbg.aiw[pageTitle="forums"] a[aria-label="Gmail"]::after {
+
+.w-asV.bbg.aiw[pageTitle='forums'] a[aria-label='Gmail']::after {
   content: 'Forums';
 }
-.w-asV.bbg.aiw[pageTitle="promotions"] a[aria-label="Gmail"]::after {
+
+.w-asV.bbg.aiw[pageTitle='promotions'] a[aria-label='Gmail']::after {
   content: 'Promotions';
 }
-.w-asV.bbg.aiw[pageTitle="labels"] a[aria-label="Gmail"]::after {
+
+.w-asV.bbg.aiw[pageTitle='labels'] a[aria-label='Gmail']::after {
   content: 'Labels';
 }
-.w-asV.bbg.aiw[pageTitle="label"] a[aria-label="Gmail"]::after {
+
+.w-asV.bbg.aiw[pageTitle='label'] a[aria-label='Gmail']::after {
   content: attr(data-label-title);
 }
 
@@ -1624,73 +1680,89 @@ input.gb_3e {
 }
 
 /* Gmail icon (old, new) */
-a[aria-label="Gmail"] {
+a[aria-label='Gmail'] {
   width: 120px;
   overflow: hidden;
   text-decoration: none;
 }
-a[aria-label="Gmail"] img {
+
+a[aria-label='Gmail'] img {
   display: none;
 }
 
 /* Fix for padding applied to a[href="#inbox"] */
+
 /* All titles get padding, lines up with sidebar icons */
-a[aria-label="Gmail"][href^="#"] {
+a[aria-label='Gmail'][href^='#'] {
   padding-left: 22px;
 }
 
 /* Gmail text */
-a[aria-label="Gmail"]::after {
+a[aria-label='Gmail']::after {
   content: 'Search';
   font-size: 20px;
-  color: #FFF;
+  color: #fff;
   position: relative;
   top: -2px;
   padding-left: 7px;
 }
 
-a[aria-label="Gmail"][href="#inbox"]::after, a[aria-label="Gmail"][href="#settings"]::after {
+a[aria-label='Gmail'][href='#inbox']::after,
+a[aria-label='Gmail'][href='#settings']::after {
   content: 'Inbox';
 }
-a[aria-label="Gmail"][href="#snoozed"]::after {
+
+a[aria-label='Gmail'][href='#snoozed']::after {
   content: 'Snoozed';
 }
-a[aria-label="Gmail"][href="#archive"]::after {
+
+a[aria-label='Gmail'][href='#archive']::after {
   content: 'Done';
 }
-a[aria-label="Gmail"][href="#starred"]::after {
+
+a[aria-label='Gmail'][href='#starred']::after {
   content: 'Starred';
 }
-a[aria-label="Gmail"][href="#sent"]::after {
+
+a[aria-label='Gmail'][href='#sent']::after {
   content: 'Sent';
 }
-a[aria-label="Gmail"][href="#drafts"]::after {
+
+a[aria-label='Gmail'][href='#drafts']::after {
   content: 'Drafts';
 }
-a[aria-label="Gmail"][href="#imp"]::after {
+
+a[aria-label='Gmail'][href='#imp']::after {
   content: 'Important';
 }
-a[aria-label="Gmail"][href="#chat"]::after,
-a[aria-label="Gmail"][href="#onboarding"]::after,
-a[aria-label="Gmail"][href="#browse"]::after {
+
+a[aria-label='Gmail'][href='#chat']::after,
+a[aria-label='Gmail'][href='#onboarding']::after,
+a[aria-label='Gmail'][href='#browse']::after {
   content: 'Chat';
 }
-a[aria-label="Gmail"][href="#calls"]::after {
+
+a[aria-label='Gmail'][href='#calls']::after {
   content: 'Meet';
 }
-a[aria-label="Gmail"][href="#scheduled"]::after {
+
+a[aria-label='Gmail'][href='#scheduled']::after {
   content: 'Scheduled';
 }
-a[aria-label="Gmail"][href="#all"]::after {
+
+a[aria-label='Gmail'][href='#all']::after {
   content: 'All Mail';
 }
-a[aria-label="Gmail"][href="#spam"]::after {
+
+a[aria-label='Gmail'][href='#spam']::after {
   content: 'Spam';
 }
-a[aria-label="Gmail"][href="#trash"]::after {
+
+a[aria-label='Gmail'][href='#trash']::after {
   content: 'Trash';
 }
-a[aria-label="Gmail"][href="#sub"]::after {
+
+a[aria-label='Gmail'][href='#sub']::after {
   content: 'Subscriptions';
 }
 
@@ -1701,55 +1773,60 @@ a[aria-label="Gmail"][href="#sub"]::after {
 
 /* Top bar icons */
 header svg {
-  color: #FFF !important;
+  color: #fff !important;
   opacity: 1 !important;
 }
 
 /* Top bar Google Chat status selector */
-.lJradf.X72uL { /* bg */
-  background: rgba(255, 255, 255, 0.125) !important;
+.lJradf.X72uL {
+  /* bg */
+  background: rgb(255 255 255 / 12.5%) !important;
 }
 
 .lJradf.X72uL:not(.Dnplmc):hover {
-  background: rgba(60, 64, 67, 0.08) !important;
+  background: rgb(60 64 67 / 8%) !important;
 }
 
-.C2Qm1d.X72uL { /* Text */
-  color: #FFF !important;
+.C2Qm1d.X72uL {
+  /* Text */
+  color: #fff !important;
 }
 
 /* ? icon */
-.t6.zH[aria-expanded="true"]:hover, .t6.zH[aria-expanded="true"] {
-  background-color: rgba(95,99,104,0.24);
+.t6.zH[aria-expanded='true']:hover,
+.t6.zH[aria-expanded='true'] {
+  background-color: rgb(95 99 104 / 24%);
 }
 
 /* settings icon */
-.FH[aria-expanded="true"]:hover {
-  background-color: rgba(95,99,104,0.24);
+.FH[aria-expanded='true']:hover {
+  background-color: rgb(95 99 104 / 24%);
 }
 
 /* gapps shorcut (expanded) icon */
-.gb_B[aria-expanded="true"] .gb_F {
+.gb_B[aria-expanded='true'] .gb_F {
   fill: #fff !important;
 }
 
 /* Search bar (old, new) */
 header form {
-  background: rgba(255, 255, 255, 0.125) !important;
+  background: rgb(255 255 255 / 12.5%) !important;
   max-width: 90% !important;
 }
 
 /* Search bar icon on active input (old, new) */
-.gb_1e.gb_yf.gb_if button svg, .gb_2e.gb_zf.gb_jf button svg {
+.gb_1e.gb_yf.gb_if button svg,
+.gb_2e.gb_zf.gb_jf button svg {
   color: #000 !important;
 }
+
 .gb_if {
   margin-top: -5px;
 }
 
 /* Search bar placeholder (old, new) */
 header form input::placeholder {
-  color: #FFF !important;
+  color: #fff !important;
 }
 
 /* Search bar input */
@@ -1771,13 +1848,17 @@ header form input {
   border-radius: 50%;
   padding: 0;
   overflow: hidden;
-  box-shadow: 0 1px 2px 0 rgba(60,64,67,0.302), 0 1px 3px 1px rgba(60,64,67,0.149);
+  box-shadow:
+    0 1px 2px 0 rgb(60 64 67 / 30.2%),
+    0 1px 3px 1px rgb(60 64 67 / 14.9%);
   cursor: pointer;
 }
 
 .add-reminder:hover,
 .floating-compose:hover {
-  box-shadow: 0 1px 3px 0 rgba(60,64,67,0.302), 0 4px 8px 3px rgba(60,64,67,0.149);
+  box-shadow:
+    0 1px 3px 0 rgb(60 64 67 / 30.2%),
+    0 4px 8px 3px rgb(60 64 67 / 14.9%);
 }
 
 /* Add reminder button */
@@ -1822,6 +1903,7 @@ header form input {
   height: 56px;
   width: 56px;
 }
+
 .floating-compose:hover::before {
   background-image: url('chrome-extension://__MSG_@@extension_id__/images/btw_ic_speeddial_compose_white_24dp_2x.png') !important;
 }
@@ -1834,18 +1916,22 @@ header form input {
 /* But show New chat button + re-style to match */
 .T-I.T-I-KE.L3.aDV {
   position: fixed;
-  left: 0; 
+  left: 0;
   bottom: 20px;
   z-index: 4;
   padding: 0;
   width: 52px;
   height: 52px;
   border-radius: 26px;
-  box-shadow: 0 1px 2px 0 rgba(60,64,67,0.302), 0 1px 3px 1px rgba(60,64,67,0.149);
+  box-shadow:
+    0 1px 2px 0 rgb(60 64 67 / 30.2%),
+    0 1px 3px 1px rgb(60 64 67 / 14.9%);
 }
 
 .T-I.T-I-KE.L3.aDV:hover {
-  box-shadow: 0 1px 3px 0 rgba(60,64,67,0.302), 0 4px 8px 3px rgba(60,64,67,0.149);
+  box-shadow:
+    0 1px 3px 0 rgb(60 64 67 / 30.2%),
+    0 4px 8px 3px rgb(60 64 67 / 14.9%);
 }
 
 .aqn.arL.nH.oy8Mbf.apV .T-I.T-I-KE.L3.aDV {
@@ -1853,7 +1939,8 @@ header form input {
 }
 
 /* Archive button (inbox email, opened email) */
-.brq, .ar8,
+.brq,
+.ar8,
 .ar8.T-I-J3.J-J5-Ji {
   -webkit-mask-image: url('chrome-extension://__MSG_@@extension_id__/images/archive_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
   mask-image: url('chrome-extension://__MSG_@@extension_id__/images/archive_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
@@ -1871,37 +1958,42 @@ header form input {
 }
 
 /* Force archive icon styling - override any conflicting styles */
-.brq::before, .ar8::before,
+.brq::before,
+.ar8::before,
 .ar8.T-I-J3.J-J5-Ji::before {
   display: none !important;
 }
 
-.brq::after, .ar8::after,
+.brq::after,
+.ar8::after,
 .ar8.T-I-J3.J-J5-Ji::after {
   display: none !important;
 }
 
-
-
 /* Snooze button (inbox email, opened email) */
-.brv, .brW {
+.brv,
+.brW {
   background-size: 20px !important;
 }
 
 @-moz-document url-prefix() {
   /* Add reminder button image */
   .add-reminder::before {
-    background-image: url('moz-extension://__MSG_@@extension_id__/images/btw_ic_speeddial_reminders_white_24dp_2x.png') !important
+    background-image: url('moz-extension://__MSG_@@extension_id__/images/btw_ic_speeddial_reminders_white_24dp_2x.png') !important;
   }
+
   /* Compose email image */
   .floating-compose::before {
     background-image: url('moz-extension://__MSG_@@extension_id__/images/btw_ic_speeddial_white_24dp_2x.png') !important;
   }
+
   .floating-compose:hover::before {
     background-image: url('moz-extension://__MSG_@@extension_id__/images/btw_ic_speeddial_compose_white_24dp_2x.png') !important;
   }
+
   /* Archive button (inbox email, opened email) */
-  .brq, .ar8,
+  .brq,
+  .ar8,
   .ar8.T-I-J3.J-J5-Ji {
     -webkit-mask-image: url('moz-extension://__MSG_@@extension_id__/images/archive_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
     mask-image: url('moz-extension://__MSG_@@extension_id__/images/archive_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
@@ -1917,10 +2009,6 @@ header form input {
     outline: none !important;
     box-shadow: none !important;
   }
-  
-
-  
-
 }
 
 /* Action buttons on email row */
@@ -1946,9 +2034,12 @@ header form input {
 /* Opened email */
 .Bs.nH.iY.bAt {
   margin: 10px;
-  box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0,0,0,.12), 0 2px 4px rgba(0,0,0,.24) !important;
+  box-shadow:
+    0 -1px 0 #e0e0e0,
+    0 0 2px rgb(0 0 0 / 12%),
+    0 2px 4px rgb(0 0 0 / 24%) !important;
   width: calc(100% - 62px);
-  background: #FFF;
+  background: #fff;
 }
 
 /* Fix bug that would expand the message area if giant image in message */
@@ -1975,15 +2066,19 @@ header form input {
 
 /* Attachments styling to look more like inbox */
 .brd {
-  margin-left: 0px !important;
+  margin-left: 0 !important;
 }
+
 .brc {
   border-radius: 2px !important;
   background-color: #f7f7f7;
   padding: 0 6px !important;
   color: #212121 !important;
-  box-shadow: 0 0 1px rgba(0,0,0,.11), 0 1px 2px rgba(0,0,0,.22) !important;
+  box-shadow:
+    0 0 1px rgb(0 0 0 / 11%),
+    0 1px 2px rgb(0 0 0 / 22%) !important;
 }
+
 .brc .brg {
   font-size: 13px !important;
 }
@@ -1996,6 +2091,7 @@ header form input {
 .zA .apU.xY {
   margin-right: 2px;
 }
+
 .zA .xW.xY {
   margin-left: -32px;
   margin-right: 10px;
@@ -2011,9 +2107,11 @@ header form input {
 .zA .apU.xY .aXw {
   display: none;
 }
+
 .zA .apU.xY .T-KT-JW {
   display: flex;
 }
+
 .aqw .apU.xY .aXw {
   display: flex;
 }
@@ -2029,7 +2127,7 @@ header form input {
 
 /* Hides pale blue on bottom for side panel */
 .aUx {
-  min-height: calc(100vh - 64px);	
+  min-height: calc(100vh - 64px);
 }
 
 /* Fixes box-shadow getting cutoff by parent */
@@ -2081,6 +2179,7 @@ header form input {
 .zA.btb {
   padding-left: 5px !important; /* Restore original - needed for blue bar positioning */
 }
+
 .zA.btb .PF.xY.PE {
   margin-right: 10px;
 }
@@ -2103,12 +2202,14 @@ header form input {
 /* Email selected with keyboard shortcut - Gmail's default blue selection */
 .zA.x7 {
   /* Let Gmail handle the default blue selection styling */
+
   /* Only adjust positioning to work with our avatar system */
 }
 
 /* Email checked/selected via checkbox - Gmail's default selection */
 .zA.aqw {
   /* Let Gmail handle the default selection styling */
+
   /* Only adjust positioning to work with our avatar system */
 }
 
@@ -2137,11 +2238,11 @@ header form input {
 }
 
 /* Alternative: Target by aria-checked attribute for checked emails */
-.show-avatar-enabled .zA .oZ-x3.xY .T-Jo[aria-checked="true"] {
+.show-avatar-enabled .zA .oZ-x3.xY .T-Jo[aria-checked='true'] {
   display: inline !important;
 }
 
-.show-avatar-enabled .zA .oZ-x3.xY .T-Jo[aria-checked="true"] + .avatar {
+.show-avatar-enabled .zA .oZ-x3.xY .T-Jo[aria-checked='true'] + .avatar {
   display: none !important;
 }
 
@@ -2150,7 +2251,7 @@ header form input {
 }
 
 /* hide the drag icon next to checkbox */
-.aqw>td.oZ-x3:before {
+.aqw > td.oZ-x3::before {
   display: none;
 }
 
@@ -2158,24 +2259,28 @@ header form input {
 .zA.aqw .oZ-x3.xY .T-Jo {
   display: inline;
 }
-.aqw .yX.xY div:nth-child(n+3)>img {
+
+.aqw .yX.xY div:nth-child(n + 3) > img {
   display: none;
 }
-.x7 .yX.xY div:nth-child(n+3)>img {
+
+.x7 .yX.xY div:nth-child(n + 3) > img {
   display: none;
 }
+
 .zA.x7 .oZ-x3.xY .T-Jo {
   display: inline;
 }
 
 /* Rearranges the menu at the top and moves it all to the right corner */
+
 /* the bar that the menu items typically rest on */
 .G-atb {
   padding-bottom: 12px !important;
 }
 
 .nH.aqK {
-  padding-top: 0px;
+  padding-top: 0;
 }
 
 .Cq.aqL {
@@ -2190,7 +2295,7 @@ header form input {
 .cL {
   font-weight: normal !important;
   font-size: 13px;
-  margin-left: 0px !important;
+  margin-left: 0 !important;
 }
 
 /* =============================================================================
@@ -2216,14 +2321,17 @@ header form input {
   overflow: visible;
 }
 
-.calendar-attachment .event-title, .calendar-attachment .event-time {
+.calendar-attachment .event-title,
+.calendar-attachment .event-time {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
 .calendar-attachment .event-title {
   font-weight: normal;
 }
+
 .calendar-attachment .event-time {
   color: #757575;
 }
@@ -2246,6 +2354,7 @@ header form input {
   background-size: 200%;
   margin-right: 16px;
 }
+
 @-moz-document url-prefix() {
   .calendar-image {
     background-image: url('moz-extension://__MSG_@@extension_id__/images/calendar_event_attachment.png') !important;
@@ -2266,8 +2375,9 @@ header form input {
   height: 22px !important;
   border-radius: 2px !important;
 }
+
 /* Hides inline "Inbox" label on emails within bundles + labels */
-.ar:has(.at[title=Inbox]) {
+.ar:has(.at[title='Inbox']) {
   display: none;
 }
 
@@ -2279,7 +2389,7 @@ header form input {
 .avatar {
   border-radius: 50%;
   font-size: 18px;
-  font-family: 'Roboto', sans-serif;
+  font-family: Roboto, sans-serif;
   font-weight: 400;
   position: relative;
   left: -6px; /* Restore original positioning from light theme */
@@ -2308,17 +2418,19 @@ header form input {
 }
 
 .reminder .avatar {
-  background: url('chrome-extension://__MSG_@@extension_id__/images/ic_reminder_blue_24dp_r2_2x.png') center/75% no-repeat !important;
+  background: url('chrome-extension://__MSG_@@extension_id__/images/ic_reminder_blue_24dp_r2_2x.png')
+    center/75% no-repeat !important;
 }
 
 @-moz-document url-prefix() {
   .reminder .avatar {
-    background: url('moz-extension://__MSG_@@extension_id__/images/ic_reminder_blue_24dp_r2_2x.png') center/75% no-repeat !important;
+    background: url('moz-extension://__MSG_@@extension_id__/images/ic_reminder_blue_24dp_r2_2x.png')
+      center/75% no-repeat !important;
   }
 }
 
 /* Alignment of calendar icon */
-.zA>.yf {
+.zA > .yf {
   padding-right: 32px !important;
 }
 
@@ -2328,8 +2440,8 @@ header form input {
 }
 
 /* Right side Hangouts */
-div[aria-label="Hangouts"][role="complementary"] {
-  background-color: rgb(242, 242, 242) !important;
+div[aria-label='Hangouts'][role='complementary'] {
+  background-color: rgb(242 242 242) !important;
 }
 
 .nH.bkK.nn + .nH.nn {
@@ -2337,7 +2449,8 @@ div[aria-label="Hangouts"][role="complementary"] {
 }
 
 /* Subject padding in opened email */
-.if > .byY, .iC .byY {
+.if > .byY,
+.iC .byY {
   padding: 20px 4px 8px 20px !important;
 }
 
@@ -2352,7 +2465,7 @@ div[aria-label="Hangouts"][role="complementary"] {
 }
 
 /* Hide the drag icon next to checkbox */
-.aqw > td.oZ-x3:before {
+.aqw > td.oZ-x3::before {
   display: none;
 }
 
@@ -2385,10 +2498,11 @@ div[aria-label="Hangouts"][role="complementary"] {
   display: inline-block;
   width: 28px;
   height: 28px !important;
-  vertical-align:middle;
-  margin-top:-4px;
-  margin-bottom:-4px;
+  vertical-align: middle;
+  margin-top: -4px;
+  margin-bottom: -4px;
 }
+
 .bundle-image img {
   width: 28px;
 }
@@ -2398,14 +2512,17 @@ div[aria-label="Hangouts"][role="complementary"] {
   font-size: 13px;
   margin-right: 32px;
 }
+
 /* allows user-specified custom color labels/bundles */
-.bundle-wrapper .label-link[style="color: rgb(225, 227, 225)"] {
+.bundle-wrapper .label-link[style='color: rgb(225, 227, 225)'] {
   color: #404040 !important;
 }
+
 .bundle-wrapper.contains-unread .label-link,
 .bundle-wrapper .bundle-senders span.strong {
   font-weight: 700;
 }
+
 .bundle-wrapper:not(.contains-unread) .bundle-image img {
   opacity: 0.6;
 }
@@ -2413,6 +2530,7 @@ div[aria-label="Hangouts"][role="complementary"] {
 .bundle-senders {
   color: #202124 !important;
 }
+
 /* Parent of .bundle-senders */
 .label-link + .xW.xY {
   flex-grow: 1;
@@ -2426,28 +2544,34 @@ div[aria-label="Hangouts"][role="complementary"] {
 }
 
 /* Colored bundle titles for Inbox categories */
-.zA.yO[bundleLabel="Updates"] .label-link > span:not(.bundle-count) {
-  color: rgb(255, 104, 57);
+.zA.yO[bundleLabel='Updates'] .label-link > span:not(.bundle-count) {
+  color: rgb(255 104 57);
 }
-.zA.yO[bundleLabel="Promotions"] .label-link > span:not(.bundle-count) {
-  color: rgb(0, 188, 212);
+
+.zA.yO[bundleLabel='Promotions'] .label-link > span:not(.bundle-count) {
+  color: rgb(0 188 212);
 }
-.zA.yO[bundleLabel="Forums"] .label-link > span:not(.bundle-count) {
-  color: rgb(63, 81, 181);
+
+.zA.yO[bundleLabel='Forums'] .label-link > span:not(.bundle-count) {
+  color: rgb(63 81 181);
 }
-.zA.yO[bundleLabel="Social"] .label-link > span:not(.bundle-count) {
-  color: rgb(219, 68, 55);
+
+.zA.yO[bundleLabel='Social'] .label-link > span:not(.bundle-count) {
+  color: rgb(219 68 55);
 }
-.zA.yO[bundleLabel="Travel"] .label-link > span:not(.bundle-count),
-.zA.yO[bundleLabel="Trips"] .label-link > span:not(.bundle-count) {
-  color: rgb(156, 39, 176);
+
+.zA.yO[bundleLabel='Travel'] .label-link > span:not(.bundle-count),
+.zA.yO[bundleLabel='Trips'] .label-link > span:not(.bundle-count) {
+  color: rgb(156 39 176);
 }
-.zA.yO[bundleLabel^="Finance"] .label-link > span:not(.bundle-count) {
-  color: rgb(103, 159, 56);
+
+.zA.yO[bundleLabel^='Finance'] .label-link > span:not(.bundle-count) {
+  color: rgb(103 159 56);
 }
-.zA.yO[bundleLabel="Orders"] .label-link > span:not(.bundle-count),
-.zA.yO[bundleLabel="Purchases"] .label-link > span:not(.bundle-count) {
-  color: rgb(121, 85, 72);
+
+.zA.yO[bundleLabel='Orders'] .label-link > span:not(.bundle-count),
+.zA.yO[bundleLabel='Purchases'] .label-link > span:not(.bundle-count) {
+  color: rgb(121 85 72);
 }
 
 .bundled-email {
@@ -2460,37 +2584,37 @@ div[aria-label="Hangouts"][role="complementary"] {
 }
 
 /* allows user-specified custom color labels/bundles */
-.zA > .xY.bundle-image[style*="background-color: rgb(225, 227, 225)"] {
+.zA > .xY.bundle-image[style*='background-color: rgb(225, 227, 225)'] {
   background-color: #444 !important;
 }
 
-.zA[bundlelabel^="Finance"] > .xY.bundle-image {
-  background-color: rgb(103, 159, 56) !important;
+.zA[bundlelabel^='Finance'] > .xY.bundle-image {
+  background-color: rgb(103 159 56) !important;
 }
 
-.zA[bundlelabel="Forums"] > .xY.bundle-image {
-  background-color: rgb(63, 81, 181) !important;
+.zA[bundlelabel='Forums'] > .xY.bundle-image {
+  background-color: rgb(63 81 181) !important;
 }
 
-.zA[bundlelabel="Orders"] > span.oZ-x3,
-.zA[bundlelabel="Purchases"] > span.oZ-x3 {
-  background-color: rgb(121, 85, 72) !important;
+.zA[bundlelabel='Orders'] > span.oZ-x3,
+.zA[bundlelabel='Purchases'] > span.oZ-x3 {
+  background-color: rgb(121 85 72) !important;
 }
 
-.zA[bundlelabel="Promotions"] > span.oZ-x3 {
-  background-color: rgb(0,188,212) !important;
+.zA[bundlelabel='Promotions'] > span.oZ-x3 {
+  background-color: rgb(0 188 212) !important;
 }
 
-.zA[bundlelabel="Social"] > span.oZ-x3 {
-  background-color: rgb(219, 68, 55) !important;
+.zA[bundlelabel='Social'] > span.oZ-x3 {
+  background-color: rgb(219 68 55) !important;
 }
 
-.zA[bundlelabel="Travel"] > span.oZ-x3 {
-  background-color: rgb(156, 39, 176) !important;
+.zA[bundlelabel='Travel'] > span.oZ-x3 {
+  background-color: rgb(156 39 176) !important;
 }
 
-.zA[bundlelabel="Updates"] > span.oZ-x3 {
-  background-color: rgb(255, 104, 57) !important;
+.zA[bundlelabel='Updates'] > span.oZ-x3 {
+  background-color: rgb(255 104 57) !important;
 }
 
 .hide-important-markers {
@@ -2505,36 +2629,42 @@ body.email-bundling-enabled.bundle-page .nH.ar4.B .yi {
 
 /* Override narrow width class */
 .Zs .zA {
-    -webkit-flex-wrap: nowrap !important;
+  -webkit-flex-wrap: nowrap !important;
   flex-wrap: nowrap !important;
 }
+
 .Zs .zA > .a4W {
   margin-left: unset !important;
 }
+
 .Zs .a4W .xT {
   flex-wrap: unset !important;
 }
+
 .Zs .yi {
   margin-left: 0 !important;
   max-width: unset !important;
 }
+
 .Zs .y2 {
   min-width: unset !important;
   -webkit-flex: 1 !important;
   flex: 1 !important;
 }
+
 .Zs .zA > .xW {
-  -webkit-flex-basis: 1 !important;
-  flex-basis: 1 !important;
   flex-grow: 400 !important;
   flex-basis: 0 !important;
 }
+
 .Zs .y6 {
   order: 1 !important;
 }
+
 .Zs .zA > .yX {
   flex: initial !important;
 }
+
 .Zs .zA > .xY {
   order: 1 !important;
 }
@@ -2559,10 +2689,15 @@ span.XU {
   margin-right: 9px;
 }
 
-.G4, .GR, div[aria-label="Inbox tip"] {
+.G4,
+.GR,
+div[aria-label='Inbox tip'] {
   border: 0 !important;
   border-radius: 0 !important;
-  box-shadow: 0 -1px 0 #e0e0e0, 0 0 2px rgba(0,0,0,.12), 0 2px 4px rgba(0,0,0,.24) !important;
+  box-shadow:
+    0 -1px 0 #e0e0e0,
+    0 0 2px rgb(0 0 0 / 12%),
+    0 2px 4px rgb(0 0 0 / 24%) !important;
 }
 
 /* New compose button */
@@ -2571,27 +2706,29 @@ span.XU {
   bottom: 16px; /* 20px; */
   right: 38px; /* 38px */
   z-index: 1001;
-
   height: 58px !important; /* 56px */
   min-width: 58px !important; /* 56px */
-
   background-color: #d23f31 !important;
   border: 0 !important;
 }
 
-.akV:hover, .akV:focus {
+.akV:hover,
+.akV:focus {
   background-color: #d23f31 !important;
 }
 
-.akV:hover::before, .akV:focus::before {
+.akV:hover::before,
+.akV:focus::before {
   background-image: url('chrome-extension://__MSG_@@extension_id__/images/btw_ic_speeddial_compose_white_24dp_2x.png') !important;
 }
 
-@media (min-resolution:144dpi),(-webkit-min-device-pixel-ratio:1.5) {
+@media (resolution >= 144dpi), (-webkit-min-device-pixel-ratio: 1.5) {
   .akV::before {
     background-image: url('chrome-extension://__MSG_@@extension_id__/images/btw_ic_speeddial_white_24dp_2x.png') !important;
   }
-  .akV:hover::before, .akV:focus::before {
+
+  .akV:hover::before,
+  .akV:focus::before {
     background-image: url('chrome-extension://__MSG_@@extension_id__/images/btw_ic_speeddial_compose_white_24dp_2x.png') !important;
   }
 }
@@ -2600,14 +2737,19 @@ span.XU {
   .akV::before {
     background-image: url('moz-extension://__MSG_@@extension_id__/images/btw_ic_speeddial_white_24dp_2x.png') !important;
   }
-  .akV:hover::before, .akV:focus::before {
+
+  .akV:hover::before,
+  .akV:focus::before {
     background-image: url('moz-extension://__MSG_@@extension_id__/images/btw_ic_speeddial_compose_white_24dp_2x.png') !important;
   }
-  @media (min-resolution:144dpi),(-webkit-min-device-pixel-ratio:1.5) {
+
+  @media (resolution >= 144dpi), (-webkit-min-device-pixel-ratio: 1.5) {
     .akV::before {
       background-image: url('moz-extension://__MSG_@@extension_id__/images/btw_ic_speeddial_white_24dp_2x.png') !important;
     }
-    .akV:hover::before, .akV:focus::before {
+
+    .akV:hover::before,
+    .akV:focus::before {
       background-image: url('moz-extension://__MSG_@@extension_id__/images/btw_ic_speeddial_compose_white_24dp_2x.png') !important;
     }
   }
@@ -2632,15 +2774,18 @@ body:not(.dark-mode) .aeF::-webkit-scrollbar {
   background: transparent;
   transition: background 0.2s;
 }
+
 body:not(.dark-mode) .aeF::-webkit-scrollbar-thumb {
   background: transparent;
   border-radius: 8px;
   transition: background 0.2s;
 }
+
 body:not(.dark-mode) .aeF:hover::-webkit-scrollbar-thumb,
 body:not(.dark-mode) .aeF:active::-webkit-scrollbar-thumb {
   background: #a1a1a1;
 }
+
 body:not(.dark-mode) .aeF:not(:hover)::-webkit-scrollbar-thumb {
   background: transparent;
 }
@@ -2651,9 +2796,11 @@ body:not(.dark-mode) .aeF {
   scrollbar-color: transparent transparent;
   transition: scrollbar-color 0.2s;
 }
+
 body:not(.dark-mode) .aeF:hover {
   scrollbar-color: #a1a1a1 transparent;
 }
+
 body:not(.dark-mode) .aeF:not(:hover) {
   scrollbar-color: transparent transparent;
 }
@@ -2699,7 +2846,7 @@ body:not(.dark-mode) .aeF:not(:hover) {
     scrollbar-color: transparent transparent;
     transition: scrollbar-color 0.2s;
   }
-  
+
   .V3.aam.ada:hover {
     scrollbar-color: #a1a1a1 transparent;
   }
@@ -2711,23 +2858,37 @@ body:not(.dark-mode) .aeF:not(:hover) {
 
 body.dark-mode {
   background-color: #141414 !important;
-  color: #ffffff !important;
+  color: #fff !important;
 }
+
 body.dark-mode .zA,
 body.dark-mode .Cp,
 body.dark-mode .Bs.nH.iY.bAt {
   background-color: #2a2a2a !important;
 }
-body.dark-mode input:not([name="to"]):not([name="cc"]):not([name="bcc"]):not([name="subjectbox"]):not([aria-label="To recipients"]):not([aria-label="Subject"]):not([aria-label="Search mail"]):not(.ZH):not([class*="ZH"]):not(.nr):not([class*="nr"]),
-body.dark-mode textarea:not([aria-label="Message Body"]) {
+
+body.dark-mode
+  input:not(
+    [name='to'],
+    [name='cc'],
+    [name='bcc'],
+    [name='subjectbox'],
+    [aria-label='To recipients'],
+    [aria-label='Subject'],
+    [aria-label='Search mail'],
+    .ZH,
+    [class*='ZH'],
+    .nr,
+    [class*='nr']
+  ),
+body.dark-mode textarea:not([aria-label='Message Body']) {
   background-color: #3b3b3b !important;
-  color: #ffffff !important;
+  color: #fff !important;
 }
+
 body.dark-mode a {
   color: #4cc2ff !important;
 }
-
-
 
 body.dark-mode hr {
   border-color: #3b3b3b !important;
@@ -2771,7 +2932,7 @@ body.dark-mode .TO {
 }
 
 /* Exclude compose window from dark mode backgrounds - let Google handle it */
-body.dark-mode .nH.Hd[role="dialog"] {
+body.dark-mode .nH.Hd[role='dialog'] {
   background: initial !important;
   background-color: initial !important;
 }
@@ -2788,11 +2949,11 @@ body.dark-mode .ZZ {
 body.dark-mode .zA,
 body.dark-mode .Bs.nH.iY.bAt {
   background: #232323 !important; /* Dark background for read emails */
-  color: #ffffff !important;
+  color: #fff !important;
 }
 
 body.dark-mode .zA * {
-  color: #ffffff !important;
+  color: #fff !important;
 }
 
 /* Sidebar text colors */
@@ -2806,7 +2967,7 @@ body.dark-mode .aAv {
 }
 
 body.dark-mode .TO.nZ .n0 {
-  color: #ffffff !important;
+  color: #fff !important;
 }
 
 body.dark-mode .TO .n0 {
@@ -2821,6 +2982,7 @@ body.dark-mode .TO.nZ {
 /* Unread email highlight - same positioning as light mode */
 body.dark-mode .zA.zE {
   background-color: #383838 !important;
+
   /* No special padding - match light mode exactly */
 }
 
@@ -2854,19 +3016,19 @@ body.dark-mode .zA.btb .PF.xY.PE {
   margin-right: 10px !important; /* Additional right margin for .btb emails */
 }
 
-
-
 /* Removed duplicate rule - consolidated above */
 
 /* Bundle styling */
 body.dark-mode .brc {
   background-color: #3b3b3b !important;
-  color: #ffffff !important;
-  box-shadow: 0 0 1px rgba(0,0,0,.31), 0 1px 2px rgba(0,0,0,.42) !important;
+  color: #fff !important;
+  box-shadow:
+    0 0 1px rgb(0 0 0 / 31%),
+    0 1px 2px rgb(0 0 0 / 42%) !important;
 }
 
 body.dark-mode .bundle-senders {
-  color: #ffffff !important;
+  color: #fff !important;
 }
 
 body.dark-mode .bundle-wrapper .label-link .bundle-count {
@@ -2902,7 +3064,7 @@ body.dark-mode .D.E.G-atb {
 }
 
 /* Override any inline border styles on main toolbar */
-body.dark-mode .D.E.G-atb[style*="border"] {
+body.dark-mode .D.E.G-atb[style*='border'] {
   border-bottom-color: #141414 !important;
   border-left-color: #141414 !important;
   border-right-color: #141414 !important;
@@ -2922,9 +3084,9 @@ body.dark-mode .nH.aqK * {
 }
 
 /* Override any inline styles on toolbar elements */
-body.dark-mode .D.E.G-atb *[style*="border"],
-body.dark-mode .Cr.aqJ *[style*="border"],
-body.dark-mode .nH.aqK *[style*="border"] {
+body.dark-mode .D.E.G-atb *[style*='border'],
+body.dark-mode .Cr.aqJ *[style*='border'],
+body.dark-mode .nH.aqK *[style*='border'] {
   border-color: #141414 !important;
   border-bottom-color: #141414 !important;
   border-left-color: #141414 !important;
@@ -2955,7 +3117,7 @@ body.dark-mode .Q3 {
 
 body.dark .Hp {
   background-color: #141414 !important;
-  color: #ffffff !important;
+  color: #fff !important;
   border-bottom: 1px solid #141414 !important;
 }
 
@@ -2966,8 +3128,6 @@ body.dark-mode .AO * {
   border-color: #141414 !important;
 }
 
-
-
 /* Toolbar specific elements - only for main email list, not opened email view */
 body.dark-mode .nH.aqK:not(.Cr.aqJ .nH.aqK) {
   background: #141414 !important;
@@ -2976,10 +3136,6 @@ body.dark-mode .nH.aqK:not(.Cr.aqJ .nH.aqK) {
 body.dark-mode .Cq.aqL {
   background: #141414 !important;
 }
-
-
-
-
 
 body.dark-mode .bzn {
   background: #141414 !important;
@@ -3032,7 +3188,7 @@ body.dark-mode .ts {
 
 /* Search bar - match light mode styling but adapted for dark mode */
 body.dark-mode header form {
-  background: rgba(255, 255, 255, 0.08) !important; /* Semi-transparent white, darker than light mode */
+  background: rgb(255 255 255 / 8%) !important; /* Semi-transparent white, darker than light mode */
   max-width: 90% !important;
 }
 
@@ -3042,10 +3198,8 @@ body.dark-mode header form input {
 }
 
 body.dark-mode header form input::placeholder {
-  color: #FFF !important; /* Match light mode exactly */
+  color: #fff !important; /* Match light mode exactly */
 }
-
-
 
 /* Archive button - dark mode styling */
 body.dark-mode .brq,
@@ -3053,8 +3207,6 @@ body.dark-mode .ar8,
 body.dark-mode .ar8.T-I-J3.J-J5-Ji {
   background-color: #e8eaed !important; /* Light gray for better visibility in dark mode */
 }
-
-
 
 /* QUICK SETTINGS PANEL */
 body.dark-mode .IU {
@@ -3081,18 +3233,16 @@ body.dark-mode .IU .Tj {
   color: #8ab4f8 !important;
 }
 
-
-
-body.dark-mode .nH.fY [role="presentation"] a.f0 {
+body.dark-mode .nH.fY [role='presentation'] a.f0 {
   color: #a0a0a0 !important;
   opacity: 1 !important;
 }
 
-body.dark-mode .nH.fY [role="presentation"] a.f0:hover {
+body.dark-mode .nH.fY [role='presentation'] a.f0:hover {
   color: #8ab4f8 !important;
 }
 
-body.dark-mode .nH.fY [role="presentation"] a.f0[aria-selected="true"] {
+body.dark-mode .nH.fY [role='presentation'] a.f0[aria-selected='true'] {
   color: #8ab4f8 !important;
   border-bottom: 2px solid #8ab4f8 !important;
 }
@@ -3134,6 +3284,7 @@ body.dark-mode .ar4.z .TD > .TC {
     background-image: url('moz-extension://__MSG_@@extension_id__/images/ic_zero_inbox_2x_dark.png') !important;
   }
 }
+
 body.dark-mode .ar4,
 body.dark-mode .aBO,
 body.dark-mode .aB6,
@@ -3149,15 +3300,18 @@ body.dark-mode .aKh,
 body.dark-mode .aRs {
   background: #2a2a2a !important;
 }
+
 body.dark-mode .zA,
 body.dark-mode .zA:hover,
 body.dark-mode .Bs.nH.iY.bAt {
   background: #2a2a2a !important;
-  color: #ffffff !important;
+  color: #fff !important;
 }
+
 body.dark-mode .zA * {
-  color: #ffffff !important;
+  color: #fff !important;
 }
+
 body.dark-mode .TO .nU > .n0,
 body.dark-mode .TO.NQ .nU > .n0,
 body.dark-mode .TO.nZ .nU > .n0,
@@ -3166,46 +3320,59 @@ body.dark-mode .n3 > .CL > .CK,
 body.dark-mode .aAv {
   color: #c7c7c7 !important;
 }
+
 body.dark-mode .TO.nZ .n0 {
-  color: #ffffff !important;
+  color: #fff !important;
 }
+
 body.dark-mode .TO .n0 {
   color: #c7c7c7 !important;
 }
+
 body.dark-mode .brc {
   background-color: #3b3b3b !important;
-  color: #ffffff !important;
-  box-shadow: 0 0 1px rgba(0,0,0,.31), 0 1px 2px rgba(0,0,0,.42) !important;
+  color: #fff !important;
+  box-shadow:
+    0 0 1px rgb(0 0 0 / 31%),
+    0 1px 2px rgb(0 0 0 / 42%) !important;
 }
+
 body.dark-mode .bundle-senders {
-  color: #ffffff !important;
+  color: #fff !important;
 }
+
 body.dark-mode .bundle-wrapper .label-link .bundle-count {
   color: #c7c7c7 !important;
 }
+
 body.dark-mode .calendar-attachment .event-time {
   color: #c7c7c7 !important;
 }
+
 body.dark-mode .time {
   color: #c7c7c7 !important;
 }
+
 body.dark-mode .nH.bkK.nn + .nH.nn {
   background-color: #3b3b3b !important;
 }
+
 body.dark-mode .IU {
   background-color: #3b3b3b !important;
 }
+
 body.dark-mode .wT > .n3 .byl:first-child .aim:first-child .nZ {
-  background-color: rgba(255,255,255,.05) !important;
+  background-color: rgb(255 255 255 / 5%) !important;
 }
+
 /* ========================================
    EMAIL VIEWS - DARK MODE STYLING
    ======================================== */
 
 /* Email content area - match Gmail's official dark mode behavior */
 body.dark-mode .nH.a98.iY.aHo {
-  background: #ffffff !important; /* Email content stays white like Gmail */
-  background-color: #ffffff !important;
+  background: #fff !important; /* Email content stays white like Gmail */
+  background-color: #fff !important;
 }
 
 /* Email content text colors - match Gmail's white email content */
@@ -3233,7 +3400,7 @@ body.dark-mode .nH.a98.iY.aHo .T-I {
 
 /* Schedule send menu item - white background */
 body.dark-mode .nH.a98.iY.aHo .J-N.yr {
-  background-color: #ffffff !important;
+  background-color: #fff !important;
   color: #202124 !important; /* Dark text on white background */
 }
 
@@ -3256,12 +3423,12 @@ body.dark-mode .nH.a98.iY.aHo a:hover {
 }
 
 /* Reply/Forward/Send buttons - target reply/forward/send buttons */
-body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji.T-I-ax7[aria-label="Reply"],
-body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji.T-I-ax7[aria-label="Forward"],
-body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji.T-I-ax7[aria-label="Send"],
-body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji.T-I-ax7[aria-label="More send options"] {
+body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji.T-I-ax7[aria-label='Reply'],
+body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji.T-I-ax7[aria-label='Forward'],
+body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji.T-I-ax7[aria-label='Send'],
+body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji.T-I-ax7[aria-label='More send options'] {
   color: #202124 !important; /* Dark text for light button background */
-  background-color: #ffffff !important;
+  background-color: #fff !important;
   border: 1px solid #202124 !important; /* Black border for reply/forward/send buttons */
   border-width: 1px !important;
   border-style: solid !important;
@@ -3272,7 +3439,7 @@ body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji.T-I-ax7[aria-label="More send options
 }
 
 /* Remove border from Reply button specifically */
-body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji.T-I-ax7.aaq[aria-label="Reply"] {
+body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji.T-I-ax7.aaq[aria-label='Reply'] {
   border: none !important;
   border-width: 0 !important;
   border-style: none !important;
@@ -3282,7 +3449,7 @@ body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji.T-I-ax7.aaq[aria-label="Reply"] {
 
 /* Set white background for older messages button */
 body.dark-mode .nH.a98.iY.aHo .adx {
-  background-color: #ffffff !important;
+  background-color: #fff !important;
   color: #202124 !important; /* Dark text for contrast */
 }
 
@@ -3315,24 +3482,24 @@ body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji.T-I-ax7:hover {
 }
 
 /* Send+ button - blue styling for reply/compose */
-body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji[aria-label*="Send and archive"],
-body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji[aria-label*="Send & archive"],
-body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji[aria-label*="send and archive"],
-body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji[aria-label*="send & archive"],
-body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji[data-tooltip*="Send and archive"],
-body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji[data-tooltip*="Send & archive"] {
-  color: #ffffff !important; /* White text on blue background */
+body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji[aria-label*='Send and archive'],
+body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji[aria-label*='Send & archive'],
+body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji[aria-label*='send and archive'],
+body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji[aria-label*='send & archive'],
+body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji[data-tooltip*='Send and archive'],
+body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji[data-tooltip*='Send & archive'] {
+  color: #fff !important; /* White text on blue background */
   background-color: #1a73e8 !important; /* Gmail's blue for Send+ */
   border: 1px solid #1a73e8 !important;
   background-image: none !important;
 }
 
-body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji[aria-label*="Send and archive"]:hover,
-body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji[aria-label*="Send & archive"]:hover,
-body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji[aria-label*="send and archive"]:hover,
-body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji[aria-label*="send & archive"]:hover,
-body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji[data-tooltip*="Send and archive"]:hover,
-body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji[data-tooltip*="send & archive"]:hover {
+body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji[aria-label*='Send and archive']:hover,
+body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji[aria-label*='Send & archive']:hover,
+body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji[aria-label*='send and archive']:hover,
+body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji[aria-label*='send & archive']:hover,
+body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji[data-tooltip*='Send and archive']:hover,
+body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji[data-tooltip*='send & archive']:hover {
   background-color: #1557b0 !important; /* Darker blue on hover */
   border-color: #1557b0 !important;
   background-image: none !important;
@@ -3343,7 +3510,7 @@ body.dark-mode .nH.a98.iY.aHo .ajA.SK {
   background-color: #2a2a2a !important;
   color: #e8eaed !important;
   border: 1px solid #5f6368 !important;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3) !important;
+  box-shadow: 0 2px 10px rgb(0 0 0 / 30%) !important;
 }
 
 /* Dropdown menu content */
@@ -3421,8 +3588,6 @@ body.dark-mode .nH.a98.iY.aHo .aap {
   box-shadow: none !important;
 }
 
-
-
 body.dark-mode .nH.a98.iY.aHo .T-I:not(.J-J5-Ji):hover {
   background-color: transparent !important;
   border: none !important;
@@ -3432,6 +3597,7 @@ body.dark-mode .nH.a98.iY.aHo .T-I:not(.J-J5-Ji):hover {
   outline: none !important;
   box-shadow: none !important;
 }
+
 /* ========================================
    EMAIL LIST VIEW (when browsing emails)
    ======================================== */
@@ -3439,7 +3605,7 @@ body.dark-mode .nH.a98.iY.aHo .T-I:not(.J-J5-Ji):hover {
 /* Email list container background */
 body.dark-mode .nH.ar4.z {
   background: #141414 !important;
-}   
+}
 
 /* Email list container - overall background */
 body.dark-mode .wT {
@@ -3451,7 +3617,7 @@ body.dark-mode .zA,
 body.dark-mode .zA:hover,
 body.dark-mode .Bs.nH.iY.bAt {
   background: #141414 !important;
-  color: #ffffff !important;
+  color: #fff !important;
 }
 
 /* Email list scrollable area */
@@ -3464,13 +3630,14 @@ body.dark-mode .nH .AO {
   background: #141414 !important;
 }
 
-
 body.dark-mode .bundle-wrapper:not(.contains-unread) .bundle-image img {
   opacity: 0.8;
 }
+
 body.dark-mode .brc .brg {
-  color: #ffffff !important;
+  color: #fff !important;
 }
+
 body.dark-mode .aEe,
 body.dark-mode .aEc.aHS-bnr .qj {
   background-color: transparent !important;
@@ -3479,7 +3646,7 @@ body.dark-mode .aEc.aHS-bnr .qj {
 }
 
 /* Override the above rule for Categories to preserve its mask-image */
-body.dark-mode [data-tooltip="Categories"] .aEc.aHS-bnr .qj {
+body.dark-mode [data-tooltip='Categories'] .aEc.aHS-bnr .qj {
   -webkit-mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_categories_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
   mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_categories_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
   -webkit-mask-size: 24px !important;
@@ -3494,7 +3661,7 @@ body.dark-mode [data-tooltip="Categories"] .aEc.aHS-bnr .qj {
 
 /* Firefox-specific dark mode override for Categories */
 @-moz-document url-prefix() {
-  body.dark-mode [data-tooltip="Categories"] .aEc.aHS-bnr .qj {
+  body.dark-mode [data-tooltip='Categories'] .aEc.aHS-bnr .qj {
     -webkit-mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_categories_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
     mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_categories_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
     -webkit-mask-size: 24px !important;
@@ -3513,44 +3680,61 @@ body.dark-mode .aHS-bnr .qj,
 body.dark-mode .zw .aHS-bnr .qj {
   /* Let Gmail use its default colorful square icons */
 }
-body.dark-mode .G4, body.dark-mode .GR, body.dark-mode div[aria-label="Inbox tip"] {
-  box-shadow: 0 -1px 0 #3b3b3b, 0 0 2px rgba(0,0,0,.32), 0 2px 4px rgba(0,0,0,.44) !important;
+
+body.dark-mode .G4,
+body.dark-mode .GR,
+body.dark-mode div[aria-label='Inbox tip'] {
+  box-shadow:
+    0 -1px 0 #3b3b3b,
+    0 0 2px rgb(0 0 0 / 32%),
+    0 2px 4px rgb(0 0 0 / 44%) !important;
 }
+
 body.dark-mode .D.E.G-atb {
   background: #141414 !important;
 }
+
 body.dark-mode .nH > .ha > .J-J5-Ji,
 body.dark-mode .nH > .nH > .hj > .ade,
 body.dark-mode .iw > .qu > .go {
   display: none !important;
 }
+
 body.dark-mode .aTV {
   border-color: transparent transparent #3b3b3b #3b3b3b !important;
 }
+
 body.dark-mode .nH.aqK {
   background: #141414 !important;
 }
+
 body.dark-mode .no {
   background-color: #141414 !important;
 }
+
 body.dark-mode .aB6,
 body.dark-mode .bn .bl {
   background-color: #2a2a2a !important;
 }
+
 body.dark-mode .aBO {
   background-color: #2a2a2a !important;
 }
+
 body.dark-mode .bzJiD,
 body.dark-mode .vIO7af {
   background: #2a2a2a !important;
 }
+
 body.dark-mode .ar4.z .TD > .TC {
   background-color: #141414 !important;
 }
+
 body.dark-mode .nH.bkK.nn + .nH.nn {
   background-color: #3b3b3b !important;
 }
-body.dark-mode [aria-label="Hangouts"][role="complementary"] {
+
+body.dark-mode [aria-label='Hangouts'][role='complementary'] {
   background-color: #2a2a2a !important;
 }
 
@@ -3603,7 +3787,7 @@ body.dark-mode .Tm.aeJ::-webkit-scrollbar-thumb:hover {
     scrollbar-width: thin !important;
     scrollbar-color: #141414 transparent !important;
   }
-  
+
   body.dark-mode .Tm.aeJ:hover {
     scrollbar-color: #323232 transparent !important;
   }
@@ -3642,11 +3826,11 @@ body.dark-mode .aeF:not(:hover)::-webkit-scrollbar-thumb {
     scrollbar-color: transparent transparent !important;
     transition: scrollbar-color 0.2s !important;
   }
-  
+
   body.dark-mode .aeF:hover {
     scrollbar-color: #323232 transparent !important;
   }
-  
+
   body.dark-mode .aeF:not(:hover) {
     scrollbar-color: transparent transparent !important;
   }
@@ -3719,12 +3903,12 @@ body.dark-mode .nH .AO::-webkit-scrollbar {
     scrollbar-color: transparent transparent !important;
     transition: scrollbar-color 0.2s !important;
   }
-  
+
   body.dark-mode .wT:hover,
   body.dark-mode .nH .AO:hover {
     scrollbar-color: #323232 transparent !important;
   }
-  
+
   body.dark-mode .wT:not(:hover),
   body.dark-mode .nH .AO:not(:hover) {
     scrollbar-color: transparent transparent !important;
@@ -3771,7 +3955,7 @@ body.dark-mode .nH .AO::-webkit-scrollbar {
     scrollbar-width: thin !important;
     scrollbar-color: transparent transparent !important;
   }
-  
+
   .Tm.aeJ:hover {
     scrollbar-color: #a1a1a1 transparent !important;
   }
@@ -3788,6 +3972,7 @@ body.dark-mode .aUx {
 }
 
 /* Email row backgrounds - different colors for read vs unread */
+
 /* Removed duplicate rule - consolidated above */
 
 /* Dark mode email styling - match light mode behavior exactly */
@@ -3808,7 +3993,6 @@ body.dark-mode .zA:hover {
 
 /* Removed duplicate rule - consolidated above */
 
-
 body.dark-mode .zA .apU.xY .T-KT::before,
 body.dark-mode .zA .apU.xY .T-KT.xl::before,
 body.dark-mode .zA .apU.xY .T-KT.T-KT-Jp::before,
@@ -3818,6 +4002,7 @@ body.dark-mode .zA .apU.xY .T-KT.xj::before,
 body.dark-mode .zA .apU.xY .T-KT.xk::before {
   /* Keep star images, do not recolor */
 }
+
 body.dark-mode .zA .apU.xY .T-KT.xg::before,
 body.dark-mode .zA .apU.xY .T-KT.xe::before,
 body.dark-mode .zA .apU.xY .T-KT.xh::before,
@@ -3841,40 +4026,49 @@ body.dark-mode .zA .apU.xY .T-KT.xl::before {
   mask-position: center !important;
   background-image: none !important;
 }
+
 body.dark-mode .brc {
   background-color: #3b3b3b !important;
-  color: #ffffff !important;
+  color: #fff !important;
 }
+
 body.dark-mode .calendar-attachment .event-time {
   color: #c7c7c7 !important;
 }
+
 body.dark-mode .bundle-wrapper .label-link .bundle-count {
   color: #c7c7c7 !important;
 }
-body.dark-mode .bundle-senders {
-  color: #ffffff !important;
-}
 
+body.dark-mode .bundle-senders {
+  color: #fff !important;
+}
 
 body.dark-mode .D.E.G-atb::before {
   box-shadow: none !important;
 }
+
 body.dark-mode header svg {
-  color: #ffffff !important;
+  color: #fff !important;
 }
+
 body.dark-mode header form {
   /* Remove forced background - let Gmail handle it naturally */
 }
+
 body.dark-mode header form input {
   color: white !important; /* Match light mode */
   background-color: transparent !important; /* Let Gmail handle background */
 }
+
 body.dark-mode header form input::placeholder {
-  color: #FFF !important; /* Match light mode exactly */
+  color: #fff !important; /* Match light mode exactly */
 }
+
 body.dark-mode .Yc {
-  color: #ffffff !important;
+  color: #fff !important;
 }
+
 body.dark-mode .aHS-bnr .qj,
 body.dark-mode .aEc.aHS-bnr .qj,
 body.dark-mode .aEe {
@@ -3995,7 +4189,7 @@ body.dark-mode .aHS-aHP .qj {
   background-image: none !important;
 }
 
-body.dark-mode [data-tooltip="Categories"] .qj {
+body.dark-mode [data-tooltip='Categories'] .qj {
   background-color: #9f9f9f !important;
   -webkit-mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_categories_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
   mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_categories_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
@@ -4008,7 +4202,7 @@ body.dark-mode [data-tooltip="Categories"] .qj {
   background-image: none !important;
 }
 
-body.dark-mode [data-tooltip="Social"] .qj {
+body.dark-mode [data-tooltip='Social'] .qj {
   background-color: #9f9f9f !important;
   -webkit-mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_social_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
   mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_social_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
@@ -4021,7 +4215,7 @@ body.dark-mode [data-tooltip="Social"] .qj {
   background-image: none !important;
 }
 
-body.dark-mode [data-tooltip="Updates"] .qj {
+body.dark-mode [data-tooltip='Updates'] .qj {
   background-color: #9f9f9f !important;
   -webkit-mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_updates_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
   mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_updates_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
@@ -4034,7 +4228,7 @@ body.dark-mode [data-tooltip="Updates"] .qj {
   background-image: none !important;
 }
 
-body.dark-mode [data-tooltip="Forums"] .qj {
+body.dark-mode [data-tooltip='Forums'] .qj {
   background-color: #9f9f9f !important;
   -webkit-mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_forums_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
   mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_forums_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
@@ -4047,7 +4241,7 @@ body.dark-mode [data-tooltip="Forums"] .qj {
   background-image: none !important;
 }
 
-body.dark-mode [data-tooltip="Promotions"] .qj {
+body.dark-mode [data-tooltip='Promotions'] .qj {
   background-color: #9f9f9f !important;
   -webkit-mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_promotions_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
   mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_promotions_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
@@ -4197,7 +4391,7 @@ body.dark-mode [data-tooltip="Promotions"] .qj {
     background-image: none !important;
   }
 
-  body.dark-mode [data-tooltip="Categories"] .qj {
+  body.dark-mode [data-tooltip='Categories'] .qj {
     background-color: #9f9f9f !important;
     -webkit-mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_categories_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
     mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_categories_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
@@ -4210,7 +4404,7 @@ body.dark-mode [data-tooltip="Promotions"] .qj {
     background-image: none !important;
   }
 
-  body.dark-mode [data-tooltip="Social"] .qj {
+  body.dark-mode [data-tooltip='Social'] .qj {
     background-color: #9f9f9f !important;
     -webkit-mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_social_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
     mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_social_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
@@ -4223,7 +4417,7 @@ body.dark-mode [data-tooltip="Promotions"] .qj {
     background-image: none !important;
   }
 
-  body.dark-mode [data-tooltip="Updates"] .qj {
+  body.dark-mode [data-tooltip='Updates'] .qj {
     background-color: #9f9f9f !important;
     -webkit-mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_updates_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
     mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_updates_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
@@ -4236,7 +4430,7 @@ body.dark-mode [data-tooltip="Promotions"] .qj {
     background-image: none !important;
   }
 
-  body.dark-mode [data-tooltip="Forums"] .qj {
+  body.dark-mode [data-tooltip='Forums'] .qj {
     background-color: #9f9f9f !important;
     -webkit-mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_forums_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
     mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_forums_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
@@ -4249,7 +4443,7 @@ body.dark-mode [data-tooltip="Promotions"] .qj {
     background-image: none !important;
   }
 
-  body.dark-mode [data-tooltip="Promotions"] .qj {
+  body.dark-mode [data-tooltip='Promotions'] .qj {
     background-color: #9f9f9f !important;
     -webkit-mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_promotions_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
     mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_promotions_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
@@ -4262,10 +4456,14 @@ body.dark-mode [data-tooltip="Promotions"] .qj {
     background-image: none !important;
   }
 }
+
 body.dark-mode .wT > .n3 .byl:first-child .aim:first-child .nZ {
-  background-color: rgba(255,255,255,.05) !important;
+  background-color: rgb(255 255 255 / 5%) !important;
 }
-body.dark-mode .aKk>tbody, .body.dark-mode .aAA, .body.dark-mode .aRz.J-KU {
+
+body.dark-mode .aKk > tbody,
+.body.dark-mode .aAA,
+.body.dark-mode .aRz.J-KU {
   background: #2a2a2a !important;
 }
 
@@ -4274,97 +4472,119 @@ body.dark-mode .TO.nZ {
   /* slightly lighter row for active state */
   background-color: #383838 !important;
 }
+
 /* Ensure the label text on the active row stays fully white */
 body.dark-mode .TO.nZ .nU > .n0 {
-  color: #ffffff !important;
+  color: #fff !important;
 }
+
 /* Ensure the icon on the active row is also bright enough */
 body.dark-mode .TO.nZ .qj {
   opacity: 1 !important;
 }
 
-body.dark-mode .G4, body.dark-mode .GR, body.dark-mode div[aria-label="Inbox tip"] {
-  box-shadow: 0 -1px 0 #3b3b3b, 0 0 2px rgba(0,0,0,.32), 0 2px 4px rgba(0,0,0,.44) !important;
+body.dark-mode .G4,
+body.dark-mode .GR,
+body.dark-mode div[aria-label='Inbox tip'] {
+  box-shadow:
+    0 -1px 0 #3b3b3b,
+    0 0 2px rgb(0 0 0 / 32%),
+    0 2px 4px rgb(0 0 0 / 44%) !important;
 }
 
 /* Dark Mode: Header Bar Color Overrides (darker variants) */
 body.dark-mode .w-asV.bbg.aiw {
   background-color: #636360 !important; /* default darker gray */
 }
-body.dark-mode .w-asV.bbg.aiw[pageTitle="inbox"] {
+
+body.dark-mode .w-asV.bbg.aiw[pageTitle='inbox'] {
   background-color: #3060b0 !important; /* darker blue */
 }
-body.dark-mode .w-asV.bbg.aiw[pageTitle="starred"] {
+
+body.dark-mode .w-asV.bbg.aiw[pageTitle='starred'] {
   background-color: #b58b20 !important; /* darker yellow */
 }
-body.dark-mode .w-asV.bbg.aiw[pageTitle="snoozed"] {
+
+body.dark-mode .w-asV.bbg.aiw[pageTitle='snoozed'] {
   background-color: #ad4d00 !important; /* darker orange */
 }
-body.dark-mode .w-asV.bbg.aiw[pageTitle="sent"] {
+
+body.dark-mode .w-asV.bbg.aiw[pageTitle='sent'] {
   background-color: #006d63 !important; /* darker teal */
 }
-body.dark-mode .w-asV.bbg.aiw[pageTitle="drafts"] {
+
+body.dark-mode .w-asV.bbg.aiw[pageTitle='drafts'] {
   background-color: #665047 !important; /* darker brown */
 }
-body.dark-mode .w-asV.bbg.aiw[pageTitle="all"] {
+
+body.dark-mode .w-asV.bbg.aiw[pageTitle='all'] {
   background-color: #3060b0 !important; /* darker blue */
 }
-body.dark-mode .w-asV.bbg.aiw[pageTitle="spam"] {
+
+body.dark-mode .w-asV.bbg.aiw[pageTitle='spam'] {
   background-color: #9c231a !important; /* darker red */
 }
-body.dark-mode .w-asV.bbg.aiw[pageTitle="trash"] {
+
+body.dark-mode .w-asV.bbg.aiw[pageTitle='trash'] {
   background-color: #45474b !important; /* darker gray */
 }
+
 /* Social */
-body.dark-mode .w-asV.bbg.aiw[pageTitle="social"] {
+body.dark-mode .w-asV.bbg.aiw[pageTitle='social'] {
   background-color: #006d63 !important; /* darker teal */
 }
+
 /* Updates */
-body.dark-mode .w-asV.bbg.aiw[pageTitle="updates"] {
+body.dark-mode .w-asV.bbg.aiw[pageTitle='updates'] {
   background-color: #b97800 !important; /* darker gold */
 }
+
 /* Forums */
-body.dark-mode .w-asV.bbg.aiw[pageTitle="forums"] {
+body.dark-mode .w-asV.bbg.aiw[pageTitle='forums'] {
   background-color: #883a68 !important; /* darker purple */
 }
+
 /* Promotions */
-body.dark-mode .w-asV.bbg.aiw[pageTitle="promotions"] {
+body.dark-mode .w-asV.bbg.aiw[pageTitle='promotions'] {
   background-color: #648d36 !important; /* darker green */
 }
+
 /* Important */
-body.dark-mode .w-asV.bbg.aiw[pageTitle="imp"] {
+body.dark-mode .w-asV.bbg.aiw[pageTitle='imp'] {
   background-color: #b83f19 !important; /* darker red-orange */
 }
+
 /* Scheduled */
-body.dark-mode .w-asV.bbg.aiw[pageTitle="scheduled"] {
+body.dark-mode .w-asV.bbg.aiw[pageTitle='scheduled'] {
   background-color: #258458 !important; /* darker green */
 }
+
 /* Subscriptions */
-body.dark-mode .w-asV.bbg.aiw[pageTitle="sub"] {
+body.dark-mode .w-asV.bbg.aiw[pageTitle='sub'] {
   background-color: #007c8c !important; /* darker cyan */
 }
+
 /* Labels */
-body.dark-mode .w-asV.bbg.aiw[pageTitle="labels"],
-body.dark-mode .w-asV.bbg.aiw[pageTitle="label"] {
+body.dark-mode .w-asV.bbg.aiw[pageTitle='labels'],
+body.dark-mode .w-asV.bbg.aiw[pageTitle='label'] {
   background-color: #4462b1 !important; /* darker indigo */
 }
+
 /* Archive */
-body.dark-mode .w-asV.bbg.aiw[pageTitle="archive"] {
+body.dark-mode .w-asV.bbg.aiw[pageTitle='archive'] {
   background-color: #0b7244 !important; /* darker green */
 }
+
 /* Chat & Onboarding */
-body.dark-mode .w-asV.bbg.aiw[pageTitle="chat"],
-body.dark-mode .w-asV.bbg.aiw[pageTitle="onboarding"] {
+body.dark-mode .w-asV.bbg.aiw[pageTitle='chat'],
+body.dark-mode .w-asV.bbg.aiw[pageTitle='onboarding'] {
   background-color: #007c33 !important; /* darker green */
 }
+
 /* Meet */
-body.dark-mode .w-asV.bbg.aiw[pageTitle="calls"] {
+body.dark-mode .w-asV.bbg.aiw[pageTitle='calls'] {
   background-color: #9e3128 !important; /* darker red */
 }
-
-
-
-
 
 /* Make recipient chips more visible */
 body.dark-mode .vR,
@@ -4401,14 +4621,13 @@ body.dark-mode .IU .OG {
 /* Text labels for the options */
 body.dark-mode .IU .a21, /* "Chat and Meet" */
 body.dark-mode .IU .Q2,  /* Radio button labels */
-body.dark-mode .IU .ST   /* Checkbox labels */
-{
+body.dark-mode .IU .ST   /* Checkbox labels */ {
   color: #e0e0e0 !important;
 }
 
 /* The container for each section */
 body.dark-mode fieldset.VM.aiL {
-    background-color: #252526 !important;
+  background-color: #252526 !important;
 }
 
 /* Links like "Customize" and "View All" */
@@ -4421,8 +4640,7 @@ body.dark-mode .IU .Tj {
 body.dark-mode .IU .a2U, /* Chat and Meet icon */
 body.dark-mode .IU .QZ,  /* Density previews */
 body.dark-mode .IU .Vm,  /* Inbox Type previews */
-body.dark-mode .IU .XK   /* Reading Pane previews */
-{
+body.dark-mode .IU .XK   /* Reading Pane previews */ {
   filter: invert(0.85) brightness(1.5) !important;
 }
 
@@ -4442,49 +4660,51 @@ body.dark-mode .IU .Q1:checked + .Vo {
 }
 
 body.dark-mode .IU .Q1:checked + .Vo::after {
-   display: block;
-   content: '';
-   width: 8px;
-   height: 8px;
-   position: relative;
-   top: 2px;
-   left: 2px;
-   border-radius: 50%;
-   background-color: #8ab4f8 !important;
+  display: block;
+  content: '';
+  width: 8px;
+  height: 8px;
+  position: relative;
+  top: 2px;
+  left: 2px;
+  border-radius: 50%;
+  background-color: #8ab4f8 !important;
 }
 
 /* Checkbox Styling */
 body.dark-mode .IU .SS + .ST::before {
-    border-color: #888 !important;
+  border-color: #888 !important;
 }
+
 body.dark-mode .IU .SS:checked + .ST::before {
-    background-color: #8ab4f8 !important;
-    border-color: #8ab4f8 !important;
+  background-color: #8ab4f8 !important;
+  border-color: #8ab4f8 !important;
 }
+
 body.dark-mode .IU .SS:checked + .ST::after {
-    border-bottom: 2px solid #252526 !important;
-    border-right: 2px solid #252526 !important;
+  border-bottom: 2px solid #252526 !important;
+  border-right: 2px solid #252526 !important;
 }
 
 /* Remove the boxes around the radio button options */
 body.dark-mode .IU .QX,
 body.dark-mode .IU .Vn,
 body.dark-mode .IU .XL {
-    border: 1px solid transparent !important;
-    background: transparent !important;
+  border: 1px solid transparent !important;
+  background: transparent !important;
 }
 
 /* Also remove border from the preview images by default */
 body.dark-mode .IU .QZ,
 body.dark-mode .IU .Vm,
 body.dark-mode .IU .XK {
-    border: 1px solid transparent !important;
+  border: 1px solid transparent !important;
 }
 
 /* Add a blue border to the selected image to indicate selection */
 body.dark-mode .IU input:checked ~ img {
-    border-radius: 6px !important;
-    border: 2px solid #8ab4f8 !important;
+  border-radius: 6px !important;
+  border: 2px solid #8ab4f8 !important;
 }
 
 /* Ensure the text part of a selected row has no special background or border */
@@ -4498,404 +4718,407 @@ body.dark-mode .IU .Q1:checked + .Vo {
 }
 
 /* --- Final Attempt: Force remove borders from option labels --- */
-body.dark-mode .QX, body.dark-mode .Vn, body.dark-mode .XL {
-    border: 1px solid transparent !important;
+body.dark-mode .QX,
+body.dark-mode .Vn,
+body.dark-mode .XL {
+  border: 1px solid transparent !important;
 }
 
 /* Remove boxes around radio buttons in dark mode */
 body.dark-mode .Vo {
-    border: none !important;
-    background: transparent !important;
-    box-shadow: none !important;
+  border: none !important;
+  background: transparent !important;
+  box-shadow: none !important;
 }
 
 body.dark-mode .Q1:checked + .Vo {
-    border: none !important;
-    background: transparent !important;
+  border: none !important;
+  background: transparent !important;
 }
 
 body.dark-mode .Q1:checked + .Vo::after {
-    content: '';
-    display: block;
-    width: 10px;
-    height: 10px;
-    border-radius: 50%;
-    background-color: #8ab4f8 !important;
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
+  content: '';
+  display: block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background-color: #8ab4f8 !important;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
 }
 
 /* Remove boxes around radio buttons in dark mode for ALL sections */
 body.dark-mode .QX,
 body.dark-mode .Vn,
 body.dark-mode .XL {
-    border: none !important;
-    background: transparent !important;
-    box-shadow: none !important;
+  border: none !important;
+  background: transparent !important;
+  box-shadow: none !important;
 }
 
 body.dark-mode .QX label,
 body.dark-mode .Vn label,
 body.dark-mode .XL label {
-    border: none !important;
-    background: transparent !important;
+  border: none !important;
+  background: transparent !important;
 }
 
 /* Ensure the radio button indicator is clean */
 body.dark-mode .Vo,
 body.dark-mode .Q1 + .Vo {
-    border: none !important;
-    background: transparent !important;
-    box-shadow: none !important;
+  border: none !important;
+  background: transparent !important;
+  box-shadow: none !important;
 }
 
 /* Selected state indicator */
 body.dark-mode .Q1:checked + .Vo::after {
-    content: '';
-    display: block;
-    width: 10px;
-    height: 10px;
-    border-radius: 50%;
-    background-color: #8ab4f8 !important;
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
+  content: '';
+  display: block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background-color: #8ab4f8 !important;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
 }
 
 /* Dark Mode Settings Tabs Styling */
-body.dark-mode .nH.fY [role="presentation"] a.f0 {
-    color: #a0a0a0 !important;  /* Lighter gray for better readability */
-    opacity: 1 !important;  /* Remove opacity reduction */
-    transition: color 0.2s ease;
+body.dark-mode .nH.fY [role='presentation'] a.f0 {
+  color: #a0a0a0 !important; /* Lighter gray for better readability */
+  opacity: 1 !important; /* Remove opacity reduction */
+  transition: color 0.2s ease;
 }
 
-body.dark-mode .nH.fY [role="presentation"] a.f0:hover {
-    color: #8ab4f8 !important;
+body.dark-mode .nH.fY [role='presentation'] a.f0:hover {
+  color: #8ab4f8 !important;
 }
 
-body.dark-mode .nH.fY [role="presentation"] a.f0[aria-selected="true"] {
-    color: #8ab4f8 !important;
-    border-bottom: 2px solid #8ab4f8 !important;
+body.dark-mode .nH.fY [role='presentation'] a.f0[aria-selected='true'] {
+  color: #8ab4f8 !important;
+  border-bottom: 2px solid #8ab4f8 !important;
 }
 
-body.dark-mode .nH.fY [role="presentation"] {
-    background-color: transparent !important;
+body.dark-mode .nH.fY [role='presentation'] {
+  background-color: transparent !important;
 }
 
 /* Dark Mode Theme Selection Dialog Styling */
 body.dark-mode .uW2Fw-bHo {
-    background-color: #252526 !important;
-    color: #e0e0e0 !important;
+  background-color: #252526 !important;
+  color: #e0e0e0 !important;
 }
 
 /* Theme selection dialog header */
 body.dark-mode .uW2Fw-bHo .cER4xe {
-    color: #f1f1f1 !important;
+  color: #f1f1f1 !important;
 }
 
 /* Theme preview containers */
 body.dark-mode .uW2Fw-bHo .a7H {
-    background-color: #141414 !important;
-    border: 1px solid #444 !important;
+  background-color: #141414 !important;
+  border: 1px solid #444 !important;
 }
 
 /* Theme preview labels */
 body.dark-mode .uW2Fw-bHo .a7N {
-    background-color: rgba(45, 45, 48, 0.8) !important;
+  background-color: rgb(45 45 48 / 80%) !important;
 }
 
 body.dark-mode .uW2Fw-bHo .a9J {
-    color: #e0e0e0 !important;
+  color: #e0e0e0 !important;
 }
 
 /* Buttons styling */
 body.dark-mode .uW2Fw-bHo .mUIrbf-I {
-    background-color: #3a3a3a !important;
-    color: #e0e0e0 !important;
-    border: 1px solid #555 !important;
+  background-color: #3a3a3a !important;
+  color: #e0e0e0 !important;
+  border: 1px solid #555 !important;
 }
 
 body.dark-mode .uW2Fw-bHo .mUIrbf-I:hover {
-    background-color: #9f9f9f !important;
+  background-color: #9f9f9f !important;
 }
 
 body.dark-mode .uW2Fw-bHo .eV8l8d {
-    background-color: #8ab4f8 !important;
-    color: #252526 !important;
+  background-color: #8ab4f8 !important;
+  color: #252526 !important;
 }
 
 /* More Images and My Photos buttons */
 body.dark-mode .uW2Fw-bHo .fQ1uhf,
 body.dark-mode .uW2Fw-bHo .PKBsLc button {
-    background-color: #141414 !important;
-    color: #e0e0e0 !important;
-    border: 1px solid #444 !important;
+  background-color: #141414 !important;
+  color: #e0e0e0 !important;
+  border: 1px solid #444 !important;
 }
 
 body.dark-mode .uW2Fw-bHo .fQ1uhf:hover,
 body.dark-mode .uW2Fw-bHo .PKBsLc button:hover {
-    background-color: #3a3a3a !important;
+  background-color: #3a3a3a !important;
 }
 
 /* Dark Mode Theme Selection Dialog Enhanced Styling */
 body.dark-mode .uW2Fw-bHo {
-    background-color: #252526 !important;
-    color: #e0e0e0 !important;
+  background-color: #252526 !important;
+  color: #e0e0e0 !important;
 }
 
 /* Theme selection dialog header */
 body.dark-mode .uW2Fw-bHo .cER4xe {
-    color: #f1f1f1 !important;
+  color: #f1f1f1 !important;
 }
 
 /* Custom theme preview containers */
 body.dark-mode .uW2Fw-bHo .a7H {
-    background-color: #141414 !important;
-    border: 1px solid #444 !important;
-    transition: transform 0.2s ease;
+  background-color: #141414 !important;
+  border: 1px solid #444 !important;
+  transition: transform 0.2s ease;
 }
 
 body.dark-mode .uW2Fw-bHo .a7H:hover {
-    transform: scale(1.05);
-    box-shadow: 0 4px 8px rgba(0,0,0,0.3);
+  transform: scale(1.05);
+  box-shadow: 0 4px 8px rgb(0 0 0 / 30%);
 }
 
 /* Ensure theme images are fully visible */
 body.dark-mode .uW2Fw-bHo .a7G {
-    opacity: 1 !important;
-    filter: brightness(0.8);
-    transition: filter 0.2s ease;
+  opacity: 1 !important;
+  filter: brightness(0.8);
+  transition: filter 0.2s ease;
 }
 
 body.dark-mode .uW2Fw-bHo .a7G:hover {
-    filter: brightness(1);
+  filter: brightness(1);
 }
 
 /* Theme preview labels */
 body.dark-mode .uW2Fw-bHo .a7N {
-    background-color: rgba(45, 45, 48, 0.8) !important;
+  background-color: rgb(45 45 48 / 80%) !important;
 }
 
 body.dark-mode .uW2Fw-bHo .a9J {
-    color: #e0e0e0 !important;
+  color: #e0e0e0 !important;
 }
 
 /* Buttons styling - More prominent and clear */
 body.dark-mode .uW2Fw-bHo .mUIrbf-I {
-    background-color: #3a3a3a !important;
-    color: #e0e0e0 !important;
-    border: 1px solid #555 !important;
-    transition: background-color 0.2s ease, color 0.2s ease;
+  background-color: #3a3a3a !important;
+  color: #e0e0e0 !important;
+  border: 1px solid #555 !important;
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease;
 }
 
 body.dark-mode .uW2Fw-bHo .mUIrbf-I:hover {
-    background-color: #9f9f9f !important;
-    color: white !important;
+  background-color: #9f9f9f !important;
+  color: white !important;
 }
 
 /* Save button - more prominent */
 body.dark-mode .uW2Fw-bHo .eV8l8d {
-    background-color: #8ab4f8 !important;
-    color: white !important;
-    border: 1px solid #8ab4f8 !important;
-    font-weight: bold;
+  background-color: #8ab4f8 !important;
+  color: white !important;
+  border: 1px solid #8ab4f8 !important;
+  font-weight: bold;
 }
 
 body.dark-mode .uW2Fw-bHo .eV8l8d:hover {
-    background-color: #a0c4f9 !important;
+  background-color: #a0c4f9 !important;
 }
 
 /* More Images and My Photos buttons */
 body.dark-mode .uW2Fw-bHo .fQ1uhf,
 body.dark-mode .uW2Fw-bHo .PKBsLc button {
-    background-color: #141414 !important;
-    color: #e0e0e0 !important;
-    border: 1px solid #444 !important;
-    transition: background-color 0.2s ease;
+  background-color: #141414 !important;
+  color: #e0e0e0 !important;
+  border: 1px solid #444 !important;
+  transition: background-color 0.2s ease;
 }
 
 body.dark-mode .uW2Fw-bHo .fQ1uhf:hover,
 body.dark-mode .uW2Fw-bHo .PKBsLc button:hover {
-    background-color: #3a3a3a !important;
-    color: white !important;
+  background-color: #3a3a3a !important;
+  color: white !important;
 }
 
 /* Aggressive Dark Mode Theme Selection Dialog Styling */
 body.dark-mode .uW2Fw-bHo .a7G {
-    opacity: 1 !important;
-    filter: brightness(1) !important;
-    mix-blend-mode: normal !important;
+  opacity: 1 !important;
+  filter: brightness(1) !important;
+  mix-blend-mode: normal !important;
 }
 
 body.dark-mode .uW2Fw-bHo .a7H {
-    background-color: transparent !important;
-    border: none !important;
+  background-color: transparent !important;
+  border: none !important;
 }
 
 body.dark-mode .uW2Fw-bHo .a7N {
-    background-color: rgba(0,0,0,0.5) !important;
+  background-color: rgb(0 0 0 / 50%) !important;
 }
 
 /* Buttons with high contrast */
 body.dark-mode .uW2Fw-bHo .mUIrbf-I {
-    background-color: #3a3a3a !important;
-    color: #ffffff !important;
-    border: 1px solid #666 !important;
+  background-color: #3a3a3a !important;
+  color: #fff !important;
+  border: 1px solid #666 !important;
 }
 
 body.dark-mode .uW2Fw-bHo .eV8l8d {
-    background-color: #4285f4 !important;
-    color: white !important;
-    border: 1px solid #4285f4 !important;
+  background-color: #4285f4 !important;
+  color: white !important;
+  border: 1px solid #4285f4 !important;
 }
 
 body.dark-mode .uW2Fw-bHo .mUIrbf-I:hover,
 body.dark-mode .uW2Fw-bHo .eV8l8d:hover {
-    opacity: 0.9 !important;
+  opacity: 0.9 !important;
 }
 
 /* Ensure text visibility */
 body.dark-mode .uW2Fw-bHo .a9J,
 body.dark-mode .uW2Fw-bHo .mUIrbf-anl {
-    color: #ffffff !important;
+  color: #fff !important;
 }
 
 /* Extremely Aggressive Dark Mode Theme Selection Dialog Styling */
 body.dark-mode .uW2Fw-bHo .a7G,
 body.dark-mode .uW2Fw-bHo img.a7G,
 body.dark-mode .uW2Fw-bHo .a7H img.a7G {
-    opacity: 1 !important;
-    filter: brightness(1) contrast(1) saturate(1) !important;
-    mix-blend-mode: normal !important;
-    max-width: 100% !important;
-    max-height: 300px !important;
-    object-fit: cover !important;
+  opacity: 1 !important;
+  filter: brightness(1) contrast(1) saturate(1) !important;
+  mix-blend-mode: normal !important;
+  max-width: 100% !important;
+  max-height: 300px !important;
+  object-fit: cover !important;
 }
 
 body.dark-mode .uW2Fw-bHo .a7H,
 body.dark-mode .uW2Fw-bHo .a7Y {
-    background-color: transparent !important;
-    border: 1px solid rgba(255,255,255,0.1) !important;
-    transition: all 0.3s ease !important;
+  background-color: transparent !important;
+  border: 1px solid rgb(255 255 255 / 10%) !important;
+  transition: all 0.3s ease !important;
 }
 
 body.dark-mode .uW2Fw-bHo .a7H:hover,
 body.dark-mode .uW2Fw-bHo .a7Y:hover {
-    transform: scale(1.05) !important;
-    box-shadow: 0 0 10px rgba(255,255,255,0.2) !important;
+  transform: scale(1.05) !important;
+  box-shadow: 0 0 10px rgb(255 255 255 / 20%) !important;
 }
 
 body.dark-mode .uW2Fw-bHo .a7N {
-    background-color: rgba(0,0,0,0.5) !important;
-    color: #ffffff !important;
+  background-color: rgb(0 0 0 / 50%) !important;
+  color: #fff !important;
 }
 
 body.dark-mode .uW2Fw-bHo .a9J {
-    color: #ffffff !important;
+  color: #fff !important;
 }
 
 /* Button Styling with Maximum Contrast */
 body.dark-mode .uW2Fw-bHo .mUIrbf-I,
 body.dark-mode .uW2Fw-bHo .PKBsLc button {
-    background-color: #3a3a3a !important;
-    color: #ffffff !important;
-    border: 1px solid #666 !important;
-    transition: all 0.2s ease !important;
+  background-color: #3a3a3a !important;
+  color: #fff !important;
+  border: 1px solid #666 !important;
+  transition: all 0.2s ease !important;
 }
 
 body.dark-mode .uW2Fw-bHo .eV8l8d {
-    background-color: #4285f4 !important;
-    color: white !important;
-    border: 1px solid #4285f4 !important;
-    font-weight: bold !important;
+  background-color: #4285f4 !important;
+  color: white !important;
+  border: 1px solid #4285f4 !important;
+  font-weight: bold !important;
 }
 
 body.dark-mode .uW2Fw-bHo .mUIrbf-I:hover,
 body.dark-mode .uW2Fw-bHo .eV8l8d:hover {
-    opacity: 0.9 !important;
+  opacity: 0.9 !important;
 }
 
 /* Ensure text visibility */
 body.dark-mode .uW2Fw-bHo .mUIrbf-anl,
 body.dark-mode .uW2Fw-bHo .a7C {
-    color: #ffffff !important;
+  color: #fff !important;
 }
 
 /* More Images section */
 body.dark-mode .uW2Fw-bHo .fQ1uhf {
-    background-color: #141414 !important;
-    color: #ffffff !important;
-    border: 1px solid #444 !important;
+  background-color: #141414 !important;
+  color: #fff !important;
+  border: 1px solid #444 !important;
 }
 
 /* Dark Mode Theme Selection Dialog Fix */
 body.dark-mode .uW2Fw-bHo {
-    background-color: #252526 !important;
-    color: #ffffff !important;
+  background-color: #252526 !important;
+  color: #fff !important;
 }
 
 body.dark-mode .uW2Fw-bHo .a7G {
-    opacity: 1 !important;
-    filter: brightness(0.9) !important;
-    transition: filter 0.2s ease !important;
+  opacity: 1 !important;
+  filter: brightness(0.9) !important;
+  transition: filter 0.2s ease !important;
 }
 
 body.dark-mode .uW2Fw-bHo .a7G:hover {
-    filter: brightness(1) !important;
+  filter: brightness(1) !important;
 }
 
 body.dark-mode .uW2Fw-bHo .a7H,
 body.dark-mode .uW2Fw-bHo .a7Y {
-    background-color: transparent !important;
-    border: 1px solid rgba(255,255,255,0.1) !important;
+  background-color: transparent !important;
+  border: 1px solid rgb(255 255 255 / 10%) !important;
 }
 
 body.dark-mode .uW2Fw-bHo .a7N {
-    background-color: rgba(0,0,0,0.5) !important;
+  background-color: rgb(0 0 0 / 50%) !important;
 }
 
 body.dark-mode .uW2Fw-bHo .a9J {
-    color: #ffffff !important;
+  color: #fff !important;
 }
 
 body.dark-mode .uW2Fw-bHo .mUIrbf-I {
-    background-color: #3a3a3a !important;
-    color: #ffffff !important;
-    border: 1px solid #555 !important;
+  background-color: #3a3a3a !important;
+  color: #fff !important;
+  border: 1px solid #555 !important;
 }
 
 body.dark-mode .uW2Fw-bHo .eV8l8d {
-    background-color: #4285f4 !important;
-    color: white !important;
-    border: 1px solid #4285f4 !important;
+  background-color: #4285f4 !important;
+  color: white !important;
+  border: 1px solid #4285f4 !important;
 }
 
 body.dark-mode .uW2Fw-bHo .fQ1uhf {
-    background-color: #141414 !important;
-    color: #ffffff !important;
-    border: 1px solid #444 !important;
+  background-color: #141414 !important;
+  color: #fff !important;
+  border: 1px solid #444 !important;
 }
 
 body.dark-mode .uW2Fw-bHo .cER4xe {
-    color: #ffffff !important;
+  color: #fff !important;
 }
 
 /* Dark Mode Theme Dialog Overlay Fix */
 body.dark-mode .uW2Fw-bHo .a7U,
 body.dark-mode .uW2Fw-bHo .a7R {
-    display: none !important; /* remove dark overlays over thumbnails */
+  display: none !important; /* remove dark overlays over thumbnails */
 }
 
 /* Ensure button labels are bright */
 body.dark-mode .uW2Fw-bHo .mUIrbf-anl {
-    color: #ffffff !important;
+  color: #fff !important;
 }
 
 /* Dark mode: highlight UNREAD email rows */
-
 
 /* =============================
    Dark mode: compose window icon visibility
@@ -4908,8 +5131,8 @@ body.dark-mode .Hl,
 body.dark-mode .Hk,
 body.dark-mode .Hq,
 body.dark-mode .Ha,
-body.dark-mode .e5 .J-Z-I div[class*="aaA"],
-body.dark-mode .e5 .J-Z-I div[class*="aaB"] {
+body.dark-mode .e5 .J-Z-I div[class*='aaA'],
+body.dark-mode .e5 .J-Z-I div[class*='aaB'] {
   filter: brightness(0) invert(1); /* glyphs white, keep transparency */
 }
 
@@ -4929,10 +5152,10 @@ body.dark-mode .aaA,
 body.dark-mode .aaB,
 body.dark-mode .J-J5-Ji .aaA,
 body.dark-mode .J-J5-Ji .aaB,
-body.dark-mode .e5 .J-Z-I div[class*="aaA"],
-body.dark-mode .e5 .J-Z-I div[class*="aaB"] {
-  filter: none !important;               /* stop inverting whole square */
-  background-color: transparent !important;/* and keep transparent */
+body.dark-mode .e5 .J-Z-I div[class*='aaA'],
+body.dark-mode .e5 .J-Z-I div[class*='aaB'] {
+  filter: none !important; /* stop inverting whole square */
+  background-color: transparent !important; /* and keep transparent */
 }
 
 /* Apply inversion only on glyph holder */
@@ -4940,20 +5163,14 @@ body.dark-mode .a3I {
   filter: invert(1) !important;
 }
 
-
-
 /* =============================================================================
    FORCE DARK MODE OVERRIDES - HIGH PRIORITY
    ============================================================================= */
 
-
-
-
-
 /* Force right sidebar to be #141414 */
 body.dark-mode .no,
 body.dark-mode .nH.bkK.nn + .nH.nn,
-body.dark-mode [aria-label="Hangouts"][role="complementary"] {
+body.dark-mode [aria-label='Hangouts'][role='complementary'] {
   background-color: #141414 !important;
   background: #141414 !important;
 }
@@ -4986,7 +5203,7 @@ body.dark-mode .yJ {
 }
 
 /* Force Categories icon to work properly */
-body.dark-mode [data-tooltip="Categories"] .aEc.aHS-bnr .qj {
+body.dark-mode [data-tooltip='Categories'] .aEc.aHS-bnr .qj {
   -webkit-mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_categories_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
   mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_categories_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
   -webkit-mask-size: 24px !important;
@@ -5001,7 +5218,7 @@ body.dark-mode [data-tooltip="Categories"] .aEc.aHS-bnr .qj {
 
 /* Firefox-specific Categories override */
 @-moz-document url-prefix() {
-  body.dark-mode [data-tooltip="Categories"] .aEc.aHS-bnr .qj {
+  body.dark-mode [data-tooltip='Categories'] .aEc.aHS-bnr .qj {
     -webkit-mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_categories_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
     mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_categories_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
     -webkit-mask-size: 24px !important;
@@ -5028,51 +5245,51 @@ body.dark-mode .nH.fY {
 }
 
 /* Make all search form inputs light (Google's default) */
-body.dark-mode .nH.fY input[type="text"],
-body.dark-mode .nH.fY input[type="email"],
-body.dark-mode .nH.fY input[type="search"],
+body.dark-mode .nH.fY input[type='text'],
+body.dark-mode .nH.fY input[type='email'],
+body.dark-mode .nH.fY input[type='search'],
 body.dark-mode .nH.fY textarea,
 body.dark-mode .nH.fY select,
 body.dark-mode .nH.fY .ZH {
-  background-color: #ffffff !important;
-  color: #000000 !important;
+  background-color: #fff !important;
+  color: #000 !important;
 }
 
 /* Search box styling - transparent background for clean integration */
-body.dark-mode input[aria-label="Search mail"] {
+body.dark-mode input[aria-label='Search mail'] {
   background-color: transparent !important; /* Transparent background for clean look */
-  color: #ffffff !important; /* White text for contrast */
+  color: #fff !important; /* White text for contrast */
 }
 
 /* Make search form inputs light (From, To, Subject, etc.) */
 body.dark-mode .ZZ .ZH,
-body.dark-mode .ZZ input[type="text"],
-body.dark-mode .ZZ input[type="email"],
+body.dark-mode .ZZ input[type='text'],
+body.dark-mode .ZZ input[type='email'],
 body.dark-mode .ZZ input.ZH.nr,
-body.dark-mode .ZZ input[class*="ZH"],
+body.dark-mode .ZZ input[class*='ZH'],
 body.dark-mode .ZZ input.ZH.nr.aQa,
 body.dark-mode .ZZ input.ZH.nr.aQf,
 body.dark-mode .ZZ input.ZH.nr.aQd,
 body.dark-mode .ZZ input.ZH.nr.aQb,
 body.dark-mode .ZZ input.ZH.nr.aP9 {
-  background-color: #ffffff !important;
-  background: #ffffff !important;
-  color: #000000 !important;
+  background-color: #fff !important;
+  background: #fff !important;
+  color: #000 !important;
   border-color: #ccc !important;
 }
 
 /* Make search form dropdowns and additional inputs light (Size, Date within, Search scope) */
 body.dark-mode .ZZ select,
-body.dark-mode .ZZ input[type="number"],
-body.dark-mode .ZZ input[type="date"],
-body.dark-mode .ZZ input[type="datetime-local"],
-body.dark-mode .ZZ input.nr[aria-label="Size value"],
-body.dark-mode .ZZ input.nr[aria-label="Date"],
+body.dark-mode .ZZ input[type='number'],
+body.dark-mode .ZZ input[type='date'],
+body.dark-mode .ZZ input[type='datetime-local'],
+body.dark-mode .ZZ input.nr[aria-label='Size value'],
+body.dark-mode .ZZ input.nr[aria-label='Date'],
 body.dark-mode .ZZ input.nr,
-body.dark-mode .ZZ input[class*="nr"] {
-  background-color: #ffffff !important;
-  background: #ffffff !important;
-  color: #000000 !important;
+body.dark-mode .ZZ input[class*='nr'] {
+  background-color: #fff !important;
+  background: #fff !important;
+  color: #000 !important;
   border-color: #ccc !important;
 }
 
@@ -5082,17 +5299,20 @@ body.dark-mode .ZZ input[class*="nr"] {
 
 /* Reminder avatar background - same as light mode */
 body.dark-mode .reminder .avatar {
-  background: url('chrome-extension://__MSG_@@extension_id__/images/ic_reminder_blue_24dp_r2_2x.png') center/75% no-repeat !important;
+  background: url('chrome-extension://__MSG_@@extension_id__/images/ic_reminder_blue_24dp_r2_2x.png')
+    center/75% no-repeat !important;
 }
 
 /* Firefox-specific reminder avatar override - same as light mode */
 @-moz-document url-prefix() {
   body.dark-mode .reminder .avatar {
-    background: url('moz-extension://__MSG_@@extension_id__/images/ic_reminder_blue_24dp_r2_2x.png') center/75% no-repeat !important;
+    background: url('moz-extension://__MSG_@@extension_id__/images/ic_reminder_blue_24dp_r2_2x.png')
+      center/75% no-repeat !important;
   }
 }
 
 /* Complete avatar visibility control - identical to light mode */
+
 /* Hides the checkbox when not checked - same as light mode */
 body.dark-mode .show-avatar-enabled .zA .oZ-x3.xY .T-Jo {
   display: none;
@@ -5118,13 +5338,10 @@ body.dark-mode .show-avatar-enabled .zA.aqw .oZ-x3.xY .avatar {
 }
 
 /* Alternative: Target by aria-checked attribute for checked emails - same as light mode */
-body.dark-mode .show-avatar-enabled .zA .oZ-x3.xY .T-Jo[aria-checked="true"] {
+body.dark-mode .show-avatar-enabled .zA .oZ-x3.xY .T-Jo[aria-checked='true'] {
   display: inline !important;
 }
 
-body.dark-mode .show-avatar-enabled .zA .oZ-x3.xY .T-Jo[aria-checked="true"] + .avatar {
+body.dark-mode .show-avatar-enabled .zA .oZ-x3.xY .T-Jo[aria-checked='true'] + .avatar {
   display: none !important;
 }
-
-
-

--- a/src/style.css
+++ b/src/style.css
@@ -2419,11 +2419,6 @@ header form input {
   flex: 32px 0 0;
 }
 
-/* Letter avatar fallback */
-.avatar.letter-avatar {
-  /* Let JavaScript handle all styling */
-}
-
 .reminder .avatar {
   background: url('chrome-extension://__MSG_@@extension_id__/images/ic_reminder_blue_24dp_r2_2x.png')
     center/75% no-repeat !important;
@@ -2957,8 +2952,6 @@ body.dark-mode .ZZ {
   background-color: initial !important;
 }
 
-/* Removed duplicate rule - consolidated with more specific rules below */
-
 /* Email row styling - base state only */
 body.dark-mode .zA,
 body.dark-mode .Bs.nH.iY.bAt {
@@ -3029,8 +3022,6 @@ body.dark-mode .zA.btb {
 body.dark-mode .zA.btb .PF.xY.PE {
   margin-right: 10px !important; /* Additional right margin for .btb emails */
 }
-
-/* Removed duplicate rule - consolidated above */
 
 /* Bundle styling */
 body.dark-mode .brc {
@@ -3989,8 +3980,6 @@ body.dark-mode .aUx {
 
 /* Email row backgrounds - different colors for read vs unread */
 
-/* Removed duplicate rule - consolidated above */
-
 /* Dark mode email styling - match light mode behavior exactly */
 body.dark-mode .zA {
   color: #e8eaed !important; /* Lighter text for better contrast */
@@ -4006,8 +3995,6 @@ body.dark-mode .zA.zE {
 body.dark-mode .zA:hover {
   background: var(--dm-surface) !important; /* Slightly lighter on hover */
 }
-
-/* Removed duplicate rule - consolidated above */
 
 body.dark-mode .zA .apU.xY .T-KT::before,
 body.dark-mode .zA .apU.xY .T-KT.xl::before,
@@ -5251,8 +5238,6 @@ body.dark-mode [data-tooltip='Categories'] .aEc.aHS-bnr .qj {
 /* ========================================
    SEARCH FORM INPUT FIELDS - LIGHT BACKGROUNDS
    ======================================== */
-
-/* Removed duplicate rule - consolidated with more specific rules below */
 
 /* Exclude search window from dark mode - let Google handle it */
 body.dark-mode .nH.fY {

--- a/src/style.css
+++ b/src/style.css
@@ -29,13 +29,20 @@
   --color-divider: #ddd;
   --color-shadow: rgb(0 0 0 / 24%);
 
-  /* Dark mode colors (will be applied with .dark-mode class) */
-  --dark-color-background: #141414;
-  --dark-color-surface: #252526;
-  --dark-color-text-primary: #fff;
-  --dark-color-text-secondary: #c7c7c7;
-  --dark-color-divider: #3b3b3b;
-  --dark-color-shadow: rgb(0 0 0 / 44%);
+  /* Dark mode palette (applied with .dark-mode class) — OWA/Fluent-inspired
+     neutral grays instead of near-black, with Outlook's communication blue */
+  --dm-bg: #1f1f1f; /* app frame, sidebars */
+  --dm-surface: #292929; /* cards, email list, dialogs */
+  --dm-surface-raised: #333; /* menus, raised elements */
+  --dm-hover: #3d3d3d; /* hover states, inputs, dividers */
+  --dm-selected: #4a4a4a; /* selected rows */
+  --dm-border: #525252; /* strong borders */
+  --dm-border-muted: #666; /* muted borders, divider lines */
+  --dm-text-secondary: #d6d6d6;
+  --dm-text-muted: #adadad;
+  --dm-accent: #479ef5; /* links, icons, focus rings */
+  --dm-accent-surface: #62abf5; /* accent backgrounds with dark text */
+  --dm-accent-strong: #115ea3; /* primary buttons with white text */
 }
 
 /* Let Gmail use its default colorful icons for system labels */
@@ -545,7 +552,7 @@ td.apU.xY .T-KT.xf::before {
 
 /* Dark mode: Done divider */
 body.dark-mode .TO.inbox-reborn-done::after {
-  background: #5f6368 !important; /* Match trash divider dark mode color */
+  background: var(--dm-border-muted) !important; /* Match trash divider dark mode color */
 }
 
 /* Add vertical spacing after Done divider to match Categories gap */
@@ -720,7 +727,7 @@ body.dark-mode .TO.inbox-reborn-done::after {
 
 /* Settings menu background in dark mode */
 body.dark-mode .a8Y {
-  background-color: #252526 !important;
+  background-color: var(--dm-surface) !important;
 }
 
 /* =============================================================================
@@ -729,7 +736,7 @@ body.dark-mode .a8Y {
 
 /* New Label popup - improve text readability in dark mode */
 body.dark-mode .uW2Fw-bHo {
-  background-color: #2a2a2a !important;
+  background-color: var(--dm-surface) !important;
   color: #e8eaed !important;
 }
 
@@ -741,13 +748,13 @@ body.dark-mode .uW2Fw-bHo .cER4xe {
 
 /* New Label popup input fields */
 body.dark-mode .uW2Fw-bHo .a7H {
-  background-color: #3c4043 !important;
+  background-color: var(--dm-hover) !important;
   color: #e8eaed !important;
-  border: 1px solid #5f6368 !important;
+  border: 1px solid var(--dm-border-muted) !important;
 }
 
 body.dark-mode .uW2Fw-bHo .a7H:focus {
-  border-color: #8ab4f8 !important;
+  border-color: var(--dm-accent) !important;
   box-shadow: 0 0 0 2px rgb(138 180 248 / 20%) !important;
 }
 
@@ -764,18 +771,18 @@ body.dark-mode .uW2Fw-bHo .a9J {
 
 /* New Label popup buttons */
 body.dark-mode .uW2Fw-bHo .mUIrbf-I {
-  background-color: #3c4043 !important;
+  background-color: var(--dm-hover) !important;
   color: #e8eaed !important;
-  border: 1px solid #5f6368 !important;
+  border: 1px solid var(--dm-border-muted) !important;
 }
 
 body.dark-mode .uW2Fw-bHo .mUIrbf-I:hover {
-  background-color: #4c4c4c !important;
+  background-color: var(--dm-selected) !important;
 }
 
 /* New Label popup primary button (Create) */
 body.dark-mode .uW2Fw-bHo .eV8l8d {
-  background-color: #8ab4f8 !important;
+  background-color: var(--dm-accent-surface) !important;
   color: #202124 !important;
   border: none !important;
 }
@@ -787,23 +794,23 @@ body.dark-mode .uW2Fw-bHo .eV8l8d:hover {
 /* New Label popup secondary button (Cancel) */
 body.dark-mode .uW2Fw-bHo .fQ1uhf {
   background-color: transparent !important;
-  color: #8ab4f8 !important;
-  border: 1px solid #5f6368 !important;
+  color: var(--dm-accent) !important;
+  border: 1px solid var(--dm-border-muted) !important;
 }
 
 body.dark-mode .uW2Fw-bHo .fQ1uhf:hover {
-  background-color: #3c4043 !important;
-  border-color: #8ab4f8 !important;
+  background-color: var(--dm-hover) !important;
+  border-color: var(--dm-accent) !important;
 }
 
 /* New Label popup checkbox */
 body.dark-mode .uW2Fw-bHo .a7G {
-  background-color: #3c4043 !important;
-  border: 1px solid #5f6368 !important;
+  background-color: var(--dm-hover) !important;
+  border: 1px solid var(--dm-border-muted) !important;
 }
 
 body.dark-mode .uW2Fw-bHo .a7G:hover {
-  background-color: #4c4c4c !important;
+  background-color: var(--dm-selected) !important;
 }
 
 /* New Label popup dropdown arrow */
@@ -836,7 +843,7 @@ body.dark-mode .V3.aam.ada::-webkit-scrollbar-track {
 }
 
 body.dark-mode .V3.aam.ada::-webkit-scrollbar-thumb {
-  background-color: #141414 !important;
+  background-color: var(--dm-bg) !important;
   border-radius: 4px !important;
   border: none !important;
   outline: none !important;
@@ -844,22 +851,22 @@ body.dark-mode .V3.aam.ada::-webkit-scrollbar-thumb {
 }
 
 body.dark-mode .V3.aam.ada:hover::-webkit-scrollbar-thumb {
-  background-color: #323232 !important;
+  background-color: var(--dm-surface-raised) !important;
 }
 
 body.dark-mode .V3.aam.ada::-webkit-scrollbar-thumb:hover {
-  background-color: #323232 !important;
+  background-color: var(--dm-surface-raised) !important;
 }
 
 /* Firefox scrollbar styling for V3 aam ada */
 @-moz-document url-prefix() {
   body.dark-mode .V3.aam.ada {
     scrollbar-width: thin !important;
-    scrollbar-color: #141414 transparent !important;
+    scrollbar-color: var(--dm-bg) transparent !important;
   }
 
   body.dark-mode .V3.aam.ada:hover {
-    scrollbar-color: #323232 transparent !important;
+    scrollbar-color: var(--dm-surface-raised) transparent !important;
   }
 }
 
@@ -1371,7 +1378,7 @@ body.dark-mode .V3.aam.ada::-webkit-scrollbar-thumb:hover {
 
 /* Dark mode: Trash divider */
 body.dark-mode .TN.bzz.aHS-bnx::after {
-  background: #5f6368 !important; /* Match Done divider dark mode color */
+  background: var(--dm-border-muted) !important; /* Match Done divider dark mode color */
 }
 
 /* Mail / Chat / Spaces Side Panels */
@@ -2857,14 +2864,14 @@ body:not(.dark-mode) .aeF:not(:hover) {
    ============================================================================= */
 
 body.dark-mode {
-  background-color: #141414 !important;
+  background-color: var(--dm-bg) !important;
   color: #fff !important;
 }
 
 body.dark-mode .zA,
 body.dark-mode .Cp,
 body.dark-mode .Bs.nH.iY.bAt {
-  background-color: #2a2a2a !important;
+  background-color: var(--dm-surface) !important;
 }
 
 body.dark-mode
@@ -2882,16 +2889,16 @@ body.dark-mode
     [class*='nr']
   ),
 body.dark-mode textarea:not([aria-label='Message Body']) {
-  background-color: #3b3b3b !important;
+  background-color: var(--dm-hover) !important;
   color: #fff !important;
 }
 
 body.dark-mode a {
-  color: #4cc2ff !important;
+  color: var(--dm-accent) !important;
 }
 
 body.dark-mode hr {
-  border-color: #3b3b3b !important;
+  border-color: var(--dm-hover) !important;
 }
 
 /* MAIN INTERFACE DARK MODE */
@@ -2910,7 +2917,7 @@ body.dark-mode .aj5 .J-KU,
 body.dark-mode .aj5.J-KU-Jg,
 body.dark-mode .aKh,
 body.dark-mode .aRs {
-  background: #2a2a2a !important;
+  background: var(--dm-surface) !important;
 }
 
 /* Main menu - use the correct dark background */
@@ -2928,13 +2935,20 @@ body.dark-mode .byl,
 body.dark-mode .TK,
 body.dark-mode .aim,
 body.dark-mode .TO {
-  background: #141414 !important;
+  background: var(--dm-bg) !important;
 }
 
-/* Exclude compose window from dark mode backgrounds - let Google handle it */
+/* Compose window: invert the whole dialog instead of styling Gmail's
+   obfuscated classes - white flips to #1f1f1f, black text to light gray,
+   and it cannot half-apply when Gmail changes its DOM */
 body.dark-mode .nH.Hd[role='dialog'] {
-  background: initial !important;
-  background-color: initial !important;
+  filter: invert(0.88) hue-rotate(180deg);
+}
+
+/* Flip images and video back to their true colors */
+body.dark-mode .nH.Hd[role='dialog'] img,
+body.dark-mode .nH.Hd[role='dialog'] video {
+  filter: invert(1) hue-rotate(180deg);
 }
 
 /* Exclude search window from dark mode - let Google handle it */
@@ -2948,7 +2962,7 @@ body.dark-mode .ZZ {
 /* Email row styling - base state only */
 body.dark-mode .zA,
 body.dark-mode .Bs.nH.iY.bAt {
-  background: #232323 !important; /* Dark background for read emails */
+  background: var(--dm-surface) !important; /* Dark background for read emails */
   color: #fff !important;
 }
 
@@ -2963,7 +2977,7 @@ body.dark-mode .TO.nZ .nU > .n0,
 body.dark-mode .ah9 > .CJ,
 body.dark-mode .n3 > .CL > .CK,
 body.dark-mode .aAv {
-  color: #c7c7c7 !important;
+  color: var(--dm-text-secondary) !important;
 }
 
 body.dark-mode .TO.nZ .n0 {
@@ -2971,17 +2985,17 @@ body.dark-mode .TO.nZ .n0 {
 }
 
 body.dark-mode .TO .n0 {
-  color: #c7c7c7 !important;
+  color: var(--dm-text-secondary) !important;
 }
 
 /* Active sidebar item */
 body.dark-mode .TO.nZ {
-  background-color: #383838 !important;
+  background-color: var(--dm-hover) !important;
 }
 
 /* Unread email highlight - same positioning as light mode */
 body.dark-mode .zA.zE {
-  background-color: #383838 !important;
+  background-color: var(--dm-hover) !important;
 
   /* No special padding - match light mode exactly */
 }
@@ -3020,7 +3034,7 @@ body.dark-mode .zA.btb .PF.xY.PE {
 
 /* Bundle styling */
 body.dark-mode .brc {
-  background-color: #3b3b3b !important;
+  background-color: var(--dm-hover) !important;
   color: #fff !important;
   box-shadow:
     0 0 1px rgb(0 0 0 / 31%),
@@ -3032,7 +3046,7 @@ body.dark-mode .bundle-senders {
 }
 
 body.dark-mode .bundle-wrapper .label-link .bundle-count {
-  color: #c7c7c7 !important;
+  color: var(--dm-text-secondary) !important;
 }
 
 body.dark-mode .bundle-wrapper:not(.contains-unread) .bundle-image img {
@@ -3041,12 +3055,12 @@ body.dark-mode .bundle-wrapper:not(.contains-unread) .bundle-image img {
 
 /* Calendar attachments */
 body.dark-mode .calendar-attachment .event-time {
-  color: #c7c7c7 !important;
+  color: var(--dm-text-secondary) !important;
 }
 
 /* Time stamps */
 body.dark-mode .time {
-  color: #c7c7c7 !important;
+  color: var(--dm-text-secondary) !important;
 }
 
 /* ========================================
@@ -3055,43 +3069,43 @@ body.dark-mode .time {
 
 /* Main toolbar container - force dark background and borders */
 body.dark-mode .D.E.G-atb {
-  background: #141414 !important;
-  border-bottom-color: #141414 !important;
-  border-left-color: #141414 !important;
-  border-right-color: #141414 !important;
-  border-top-color: #141414 !important;
-  border-color: #141414 !important;
+  background: var(--dm-bg) !important;
+  border-bottom-color: var(--dm-bg) !important;
+  border-left-color: var(--dm-bg) !important;
+  border-right-color: var(--dm-bg) !important;
+  border-top-color: var(--dm-bg) !important;
+  border-color: var(--dm-bg) !important;
 }
 
 /* Override any inline border styles on main toolbar */
 body.dark-mode .D.E.G-atb[style*='border'] {
-  border-bottom-color: #141414 !important;
-  border-left-color: #141414 !important;
-  border-right-color: #141414 !important;
-  border-top-color: #141414 !important;
-  border-color: #141414 !important;
+  border-bottom-color: var(--dm-bg) !important;
+  border-left-color: var(--dm-bg) !important;
+  border-right-color: var(--dm-bg) !important;
+  border-top-color: var(--dm-bg) !important;
+  border-color: var(--dm-bg) !important;
 }
 
 /* Force all toolbar elements to have dark borders */
 body.dark-mode .D.E.G-atb *,
 body.dark-mode .Cr.aqJ *,
 body.dark-mode .nH.aqK * {
-  border-color: #141414 !important;
-  border-bottom-color: #141414 !important;
-  border-left-color: #141414 !important;
-  border-right-color: #141414 !important;
-  border-top-color: #141414 !important;
+  border-color: var(--dm-bg) !important;
+  border-bottom-color: var(--dm-bg) !important;
+  border-left-color: var(--dm-bg) !important;
+  border-right-color: var(--dm-bg) !important;
+  border-top-color: var(--dm-bg) !important;
 }
 
 /* Override any inline styles on toolbar elements */
 body.dark-mode .D.E.G-atb *[style*='border'],
 body.dark-mode .Cr.aqJ *[style*='border'],
 body.dark-mode .nH.aqK *[style*='border'] {
-  border-color: #141414 !important;
-  border-bottom-color: #141414 !important;
-  border-left-color: #141414 !important;
-  border-right-color: #141414 !important;
-  border-top-color: #141414 !important;
+  border-color: var(--dm-bg) !important;
+  border-bottom-color: var(--dm-bg) !important;
+  border-left-color: var(--dm-bg) !important;
+  border-right-color: var(--dm-bg) !important;
+  border-top-color: var(--dm-bg) !important;
 }
 
 /* Nuclear option: Force all #444 colors to #141414 in toolbar area */
@@ -3099,18 +3113,18 @@ body.dark-mode .D.E.G-atb,
 body.dark-mode .D.E.G-atb *,
 body.dark-mode .nH.aqK:not(.Cr.aqJ .nH.aqK),
 body.dark-mode .nH.aqK:not(.Cr.aqJ .nH.aqK) * {
-  border-color: #141414 !important;
-  border-bottom-color: #141414 !important;
-  border-left-color: #141414 !important;
-  border-right-color: #141414 !important;
-  border-top-color: #141414 !important;
-  background-color: #141414 !important;
+  border-color: var(--dm-bg) !important;
+  border-bottom-color: var(--dm-bg) !important;
+  border-left-color: var(--dm-bg) !important;
+  border-right-color: var(--dm-bg) !important;
+  border-top-color: var(--dm-bg) !important;
+  background-color: var(--dm-bg) !important;
 }
 
 /* Additional toolbar elements that needed border fixes */
 body.dark-mode .Q3 {
-  background-color: #252526 !important;
-  border-bottom: 1px solid #141414 !important;
+  background-color: var(--dm-surface) !important;
+  border-bottom: 1px solid var(--dm-bg) !important;
 }
 
 /* Removed conflicting rule - search window should use Google's default styling */
@@ -3125,65 +3139,65 @@ body.dark .Hp {
 body.dark-mode .AO * {
   background-color: transparent !important;
   color: #e0e0e0 !important;
-  border-color: #141414 !important;
+  border-color: var(--dm-bg) !important;
 }
 
 /* Toolbar specific elements - only for main email list, not opened email view */
 body.dark-mode .nH.aqK:not(.Cr.aqJ .nH.aqK) {
-  background: #141414 !important;
+  background: var(--dm-bg) !important;
 }
 
 body.dark-mode .Cq.aqL {
-  background: #141414 !important;
+  background: var(--dm-bg) !important;
 }
 
 body.dark-mode .bzn {
-  background: #141414 !important;
+  background: var(--dm-bg) !important;
 }
 
 body.dark-mode .G-tF {
-  background: #141414 !important;
+  background: var(--dm-bg) !important;
 }
 
 body.dark-mode .G-Ni {
-  background: #141414 !important;
+  background: var(--dm-bg) !important;
 }
 
 /* Pagination controls */
 body.dark-mode .ar5 {
-  background: #141414 !important;
-  background-color: #141414 !important;
+  background: var(--dm-bg) !important;
+  background-color: var(--dm-bg) !important;
 }
 
 body.dark-mode .Di {
-  background: #141414 !important;
-  background-color: #141414 !important;
+  background: var(--dm-bg) !important;
+  background-color: var(--dm-bg) !important;
 }
 
 body.dark-mode .amH {
-  background: #141414 !important;
-  background-color: #141414 !important;
+  background: var(--dm-bg) !important;
+  background-color: var(--dm-bg) !important;
 }
 
 body.dark-mode .amD {
-  background: #141414 !important;
-  background-color: #141414 !important;
+  background: var(--dm-bg) !important;
+  background-color: var(--dm-bg) !important;
 }
 
 body.dark-mode .amG {
-  background: #141414 !important;
-  background-color: #141414 !important;
+  background: var(--dm-bg) !important;
+  background-color: var(--dm-bg) !important;
 }
 
 /* Additional pagination elements */
 body.dark-mode .Dj {
-  background: #141414 !important;
-  background-color: #141414 !important;
+  background: var(--dm-bg) !important;
+  background-color: var(--dm-bg) !important;
 }
 
 body.dark-mode .ts {
-  background: #141414 !important;
-  background-color: #141414 !important;
+  background: var(--dm-bg) !important;
+  background-color: var(--dm-bg) !important;
 }
 
 /* Search bar - match light mode styling but adapted for dark mode */
@@ -3210,7 +3224,7 @@ body.dark-mode .ar8.T-I-J3.J-J5-Ji {
 
 /* QUICK SETTINGS PANEL */
 body.dark-mode .IU {
-  background-color: #141414 !important;
+  background-color: var(--dm-bg) !important;
 }
 
 body.dark-mode .IU .VO,
@@ -3225,12 +3239,12 @@ body.dark-mode .IU .ST {
 }
 
 body.dark-mode fieldset.VM.aiL {
-  background-color: #252526 !important;
+  background-color: var(--dm-surface) !important;
 }
 
 body.dark-mode .IU .OD,
 body.dark-mode .IU .Tj {
-  color: #8ab4f8 !important;
+  color: var(--dm-accent) !important;
 }
 
 body.dark-mode .nH.fY [role='presentation'] a.f0 {
@@ -3239,12 +3253,12 @@ body.dark-mode .nH.fY [role='presentation'] a.f0 {
 }
 
 body.dark-mode .nH.fY [role='presentation'] a.f0:hover {
-  color: #8ab4f8 !important;
+  color: var(--dm-accent) !important;
 }
 
 body.dark-mode .nH.fY [role='presentation'] a.f0[aria-selected='true'] {
-  color: #8ab4f8 !important;
-  border-bottom: 2px solid #8ab4f8 !important;
+  color: var(--dm-accent) !important;
+  border-bottom: 2px solid var(--dm-accent) !important;
 }
 
 /* EMAIL VIEWER */
@@ -3253,7 +3267,7 @@ body.dark-mode .AO {
 }
 
 body.dark-mode .AO a {
-  color: #8ab4f8 !important;
+  color: var(--dm-accent) !important;
 }
 
 /* LABELS AND CHIPS */
@@ -3298,13 +3312,13 @@ body.dark-mode .aj5 .J-KU,
 body.dark-mode .aj5.J-KU-Jg,
 body.dark-mode .aKh,
 body.dark-mode .aRs {
-  background: #2a2a2a !important;
+  background: var(--dm-surface) !important;
 }
 
 body.dark-mode .zA,
 body.dark-mode .zA:hover,
 body.dark-mode .Bs.nH.iY.bAt {
-  background: #2a2a2a !important;
+  background: var(--dm-surface) !important;
   color: #fff !important;
 }
 
@@ -3318,7 +3332,7 @@ body.dark-mode .TO.nZ .nU > .n0,
 body.dark-mode .ah9 > .CJ,
 body.dark-mode .n3 > .CL > .CK,
 body.dark-mode .aAv {
-  color: #c7c7c7 !important;
+  color: var(--dm-text-secondary) !important;
 }
 
 body.dark-mode .TO.nZ .n0 {
@@ -3326,11 +3340,11 @@ body.dark-mode .TO.nZ .n0 {
 }
 
 body.dark-mode .TO .n0 {
-  color: #c7c7c7 !important;
+  color: var(--dm-text-secondary) !important;
 }
 
 body.dark-mode .brc {
-  background-color: #3b3b3b !important;
+  background-color: var(--dm-hover) !important;
   color: #fff !important;
   box-shadow:
     0 0 1px rgb(0 0 0 / 31%),
@@ -3342,23 +3356,23 @@ body.dark-mode .bundle-senders {
 }
 
 body.dark-mode .bundle-wrapper .label-link .bundle-count {
-  color: #c7c7c7 !important;
+  color: var(--dm-text-secondary) !important;
 }
 
 body.dark-mode .calendar-attachment .event-time {
-  color: #c7c7c7 !important;
+  color: var(--dm-text-secondary) !important;
 }
 
 body.dark-mode .time {
-  color: #c7c7c7 !important;
+  color: var(--dm-text-secondary) !important;
 }
 
 body.dark-mode .nH.bkK.nn + .nH.nn {
-  background-color: #3b3b3b !important;
+  background-color: var(--dm-hover) !important;
 }
 
 body.dark-mode .IU {
-  background-color: #3b3b3b !important;
+  background-color: var(--dm-hover) !important;
 }
 
 body.dark-mode .wT > .n3 .byl:first-child .aim:first-child .nZ {
@@ -3369,57 +3383,59 @@ body.dark-mode .wT > .n3 .byl:first-child .aim:first-child .nZ {
    EMAIL VIEWS - DARK MODE STYLING
    ======================================== */
 
-/* Email content area - match Gmail's official dark mode behavior */
+/* Email content area - dark reading pane (emails with their own inline
+   backgrounds, e.g. HTML newsletters, keep them) */
 body.dark-mode .nH.a98.iY.aHo {
-  background: #fff !important; /* Email content stays white like Gmail */
-  background-color: #fff !important;
+  background: var(--dm-surface) !important;
+  background-color: var(--dm-surface) !important;
 }
 
-/* Email content text colors - match Gmail's white email content */
+/* Email content text colors - light text on dark surface */
 body.dark-mode .nH.a98.iY.aHo * {
-  color: #202124 !important; /* Dark text on white background like Gmail */
+  color: #e8eaed !important;
 }
 
-/* Email header elements - dark text on white background */
+/* Email header elements - light text on dark surface */
 body.dark-mode .nH.a98.iY.aHo .hP {
-  color: #202124 !important; /* Subject line - dark text */
+  color: #fff !important; /* Subject line */
 }
 
 body.dark-mode .nH.a98.iY.aHo .gD {
-  color: #202124 !important; /* Sender name - dark text */
+  color: #fff !important; /* Sender name */
 }
 
 body.dark-mode .nH.a98.iY.aHo .aXjCH {
-  color: #5f6368 !important; /* Timestamp - medium grey text */
+  color: var(--dm-text-muted) !important; /* Timestamp - medium grey text */
 }
 
 /* Email action buttons/icons - dark text on white background */
 body.dark-mode .nH.a98.iY.aHo .T-I {
-  color: #5f6368 !important; /* Action icons - medium grey */
+  color: var(--dm-text-muted) !important; /* Action icons - medium grey */
 }
 
-/* Schedule send menu item - white background */
+/* Schedule send menu item */
 body.dark-mode .nH.a98.iY.aHo .J-N.yr {
-  background-color: #fff !important;
-  color: #202124 !important; /* Dark text on white background */
+  background-color: var(--dm-surface-raised) !important;
+  color: #e8eaed !important;
 }
 
 body.dark-mode .nH.a98.iY.aHo .T-I:hover {
-  color: #202124 !important; /* Darker on hover */
+  color: #fff !important; /* Brighter on hover */
 }
 
-/* Email body content - dark text on white background */
+/* Email body content - light default text (inline email styles still win
+   inside messages that bring their own colors) */
 body.dark-mode .nH.a98.iY.aHo .a3s {
-  color: #202124 !important; /* Email body text - dark text */
+  color: #e8eaed !important;
 }
 
-/* Links in email - Gmail's standard link colors */
+/* Links in email */
 body.dark-mode .nH.a98.iY.aHo a {
-  color: #1a73e8 !important; /* Gmail's standard blue for light background */
+  color: var(--dm-accent) !important;
 }
 
 body.dark-mode .nH.a98.iY.aHo a:hover {
-  color: #174ea6 !important; /* Darker blue on hover */
+  color: #62abf5 !important; /* Lighter blue on hover */
 }
 
 /* Reply/Forward/Send buttons - target reply/forward/send buttons */
@@ -3427,12 +3443,12 @@ body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji.T-I-ax7[aria-label='Reply'],
 body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji.T-I-ax7[aria-label='Forward'],
 body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji.T-I-ax7[aria-label='Send'],
 body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji.T-I-ax7[aria-label='More send options'] {
-  color: #202124 !important; /* Dark text for light button background */
-  background-color: #fff !important;
-  border: 1px solid #202124 !important; /* Black border for reply/forward/send buttons */
+  color: #e8eaed !important;
+  background-color: var(--dm-surface-raised) !important;
+  border: 1px solid var(--dm-border-muted) !important;
   border-width: 1px !important;
   border-style: solid !important;
-  border-color: #202124 !important;
+  border-color: var(--dm-border-muted) !important;
   border-image: none !important;
   outline: none !important;
   box-shadow: none !important;
@@ -3447,10 +3463,10 @@ body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji.T-I-ax7.aaq[aria-label='Reply'] {
   border-image: none !important;
 }
 
-/* Set white background for older messages button */
+/* Older messages button */
 body.dark-mode .nH.a98.iY.aHo .adx {
-  background-color: #fff !important;
-  color: #202124 !important; /* Dark text for contrast */
+  background-color: var(--dm-surface-raised) !important;
+  color: #e8eaed !important;
 }
 
 /* Remove borders from action icons (reactions, etc.) */
@@ -3477,8 +3493,8 @@ body.dark-mode .nH.a98.iY.aHo .T-I:not(.J-J5-Ji) .T-I-J3 {
 }
 
 body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji.T-I-ax7:hover {
-  color: #202124 !important;
-  background-color: #f8f9fa !important;
+  color: #fff !important;
+  background-color: var(--dm-hover) !important;
 }
 
 /* Send+ button - blue styling for reply/compose */
@@ -3489,8 +3505,8 @@ body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji[aria-label*='send & archive'],
 body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji[data-tooltip*='Send and archive'],
 body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji[data-tooltip*='Send & archive'] {
   color: #fff !important; /* White text on blue background */
-  background-color: #1a73e8 !important; /* Gmail's blue for Send+ */
-  border: 1px solid #1a73e8 !important;
+  background-color: var(--dm-accent-strong) !important;
+  border: 1px solid var(--dm-accent-strong) !important;
   background-image: none !important;
 }
 
@@ -3507,9 +3523,9 @@ body.dark-mode .nH.a98.iY.aHo .T-I.J-J5-Ji[data-tooltip*='send & archive']:hover
 
 /* Email header dropdown menu - target specific class */
 body.dark-mode .nH.a98.iY.aHo .ajA.SK {
-  background-color: #2a2a2a !important;
+  background-color: var(--dm-surface) !important;
   color: #e8eaed !important;
-  border: 1px solid #5f6368 !important;
+  border: 1px solid var(--dm-border-muted) !important;
   box-shadow: 0 2px 10px rgb(0 0 0 / 30%) !important;
 }
 
@@ -3520,12 +3536,12 @@ body.dark-mode .nH.a98.iY.aHo .ajA.SK * {
 
 /* Dropdown menu item hover states */
 body.dark-mode .nH.a98.iY.aHo .ajA.SK div:hover {
-  background-color: #3c4043 !important;
+  background-color: var(--dm-hover) !important;
 }
 
 /* Links in dropdown */
 body.dark-mode .nH.a98.iY.aHo .ajA.SK a {
-  color: #8ab4f8 !important;
+  color: var(--dm-accent) !important;
 }
 
 body.dark-mode .nH.a98.iY.aHo .ajA.SK a:hover {
@@ -3604,30 +3620,30 @@ body.dark-mode .nH.a98.iY.aHo .T-I:not(.J-J5-Ji):hover {
 
 /* Email list container background */
 body.dark-mode .nH.ar4.z {
-  background: #141414 !important;
+  background: var(--dm-bg) !important;
 }
 
 /* Email list container - overall background */
 body.dark-mode .wT {
-  background-color: #4c4c4c !important;
+  background-color: var(--dm-selected) !important;
 }
 
 /* Individual email rows in the list */
 body.dark-mode .zA,
 body.dark-mode .zA:hover,
 body.dark-mode .Bs.nH.iY.bAt {
-  background: #141414 !important;
+  background: var(--dm-bg) !important;
   color: #fff !important;
 }
 
 /* Email list scrollable area */
 body.dark-mode .nH .AO .aeF {
-  background: #141414 !important;
+  background: var(--dm-bg) !important;
 }
 
 /* Email list container */
 body.dark-mode .nH .AO {
-  background: #141414 !important;
+  background: var(--dm-bg) !important;
 }
 
 body.dark-mode .bundle-wrapper:not(.contains-unread) .bundle-image img {
@@ -3655,7 +3671,7 @@ body.dark-mode [data-tooltip='Categories'] .aEc.aHS-bnr .qj {
   mask-repeat: no-repeat !important;
   -webkit-mask-position: center !important;
   mask-position: center !important;
-  background-color: #9f9f9f !important;
+  background-color: var(--dm-text-muted) !important;
   background-image: none !important;
 }
 
@@ -3670,7 +3686,7 @@ body.dark-mode [data-tooltip='Categories'] .aEc.aHS-bnr .qj {
     mask-repeat: no-repeat !important;
     -webkit-mask-position: center !important;
     mask-position: center !important;
-    background-color: #9f9f9f !important;
+    background-color: var(--dm-text-muted) !important;
     background-image: none !important;
   }
 }
@@ -3685,13 +3701,13 @@ body.dark-mode .G4,
 body.dark-mode .GR,
 body.dark-mode div[aria-label='Inbox tip'] {
   box-shadow:
-    0 -1px 0 #3b3b3b,
+    0 -1px 0 var(--dm-hover),
     0 0 2px rgb(0 0 0 / 32%),
     0 2px 4px rgb(0 0 0 / 44%) !important;
 }
 
 body.dark-mode .D.E.G-atb {
-  background: #141414 !important;
+  background: var(--dm-bg) !important;
 }
 
 body.dark-mode .nH > .ha > .J-J5-Ji,
@@ -3701,54 +3717,54 @@ body.dark-mode .iw > .qu > .go {
 }
 
 body.dark-mode .aTV {
-  border-color: transparent transparent #3b3b3b #3b3b3b !important;
+  border-color: transparent transparent var(--dm-hover) var(--dm-hover) !important;
 }
 
 body.dark-mode .nH.aqK {
-  background: #141414 !important;
+  background: var(--dm-bg) !important;
 }
 
 body.dark-mode .no {
-  background-color: #141414 !important;
+  background-color: var(--dm-bg) !important;
 }
 
 body.dark-mode .aB6,
 body.dark-mode .bn .bl {
-  background-color: #2a2a2a !important;
+  background-color: var(--dm-surface) !important;
 }
 
 body.dark-mode .aBO {
-  background-color: #2a2a2a !important;
+  background-color: var(--dm-surface) !important;
 }
 
 body.dark-mode .bzJiD,
 body.dark-mode .vIO7af {
-  background: #2a2a2a !important;
+  background: var(--dm-surface) !important;
 }
 
 body.dark-mode .ar4.z .TD > .TC {
-  background-color: #141414 !important;
+  background-color: var(--dm-bg) !important;
 }
 
 body.dark-mode .nH.bkK.nn + .nH.nn {
-  background-color: #3b3b3b !important;
+  background-color: var(--dm-hover) !important;
 }
 
 body.dark-mode [aria-label='Hangouts'][role='complementary'] {
-  background-color: #2a2a2a !important;
+  background-color: var(--dm-surface) !important;
 }
 
 body.dark-mode .nH.bAw.nn {
-  background-color: #141414 !important;
+  background-color: var(--dm-bg) !important;
 }
 
 body.dark-mode .bAw.bcf {
-  background-color: #141414 !important;
+  background-color: var(--dm-bg) !important;
 }
 
 body.dark-mode .Tm.aeJ {
-  background-color: #141414 !important;
-  background: #141414 !important;
+  background-color: var(--dm-bg) !important;
+  background: var(--dm-bg) !important;
 }
 
 /* Email view scrollbar styling */
@@ -3766,7 +3782,7 @@ body.dark-mode .Tm.aeJ::-webkit-scrollbar-track {
 }
 
 body.dark-mode .Tm.aeJ::-webkit-scrollbar-thumb {
-  background-color: #141414 !important;
+  background-color: var(--dm-bg) !important;
   border-radius: 4px !important;
   border: none !important;
   outline: none !important;
@@ -3774,22 +3790,22 @@ body.dark-mode .Tm.aeJ::-webkit-scrollbar-thumb {
 }
 
 body.dark-mode .Tm.aeJ:hover::-webkit-scrollbar-thumb {
-  background-color: #323232 !important;
+  background-color: var(--dm-surface-raised) !important;
 }
 
 body.dark-mode .Tm.aeJ::-webkit-scrollbar-thumb:hover {
-  background-color: #323232 !important;
+  background-color: var(--dm-surface-raised) !important;
 }
 
 /* Firefox scrollbar styling */
 @-moz-document url-prefix() {
   body.dark-mode .Tm.aeJ {
     scrollbar-width: thin !important;
-    scrollbar-color: #141414 transparent !important;
+    scrollbar-color: var(--dm-bg) transparent !important;
   }
 
   body.dark-mode .Tm.aeJ:hover {
-    scrollbar-color: #323232 transparent !important;
+    scrollbar-color: var(--dm-surface-raised) transparent !important;
   }
 }
 
@@ -3812,7 +3828,7 @@ body.dark-mode .aeF::-webkit-scrollbar-thumb {
 
 body.dark-mode .aeF:hover::-webkit-scrollbar-thumb,
 body.dark-mode .aeF:active::-webkit-scrollbar-thumb {
-  background: #323232 !important;
+  background: var(--dm-surface-raised) !important;
 }
 
 body.dark-mode .aeF:not(:hover)::-webkit-scrollbar-thumb {
@@ -3828,7 +3844,7 @@ body.dark-mode .aeF:not(:hover)::-webkit-scrollbar-thumb {
   }
 
   body.dark-mode .aeF:hover {
-    scrollbar-color: #323232 transparent !important;
+    scrollbar-color: var(--dm-surface-raised) transparent !important;
   }
 
   body.dark-mode .aeF:not(:hover) {
@@ -3856,7 +3872,7 @@ body.dark-mode .wT:hover::-webkit-scrollbar-thumb,
 body.dark-mode .wT:active::-webkit-scrollbar-thumb,
 body.dark-mode .nH .AO:hover::-webkit-scrollbar-thumb,
 body.dark-mode .nH .AO:active::-webkit-scrollbar-thumb {
-  background: #323232 !important;
+  background: var(--dm-surface-raised) !important;
 }
 
 body.dark-mode .wT:not(:hover)::-webkit-scrollbar-thumb,
@@ -3873,7 +3889,7 @@ body.dark-mode .nH .AO {
 
 body.dark-mode .wT:hover,
 body.dark-mode .nH .AO:hover {
-  scrollbar-color: #323232 transparent !important;
+  scrollbar-color: var(--dm-surface-raised) transparent !important;
 }
 
 body.dark-mode .wT:not(:hover),
@@ -3884,8 +3900,8 @@ body.dark-mode .nH .AO:not(:hover) {
 /* Force Chrome scrollbar colors with higher specificity */
 body.dark-mode .wT::-webkit-scrollbar-thumb,
 body.dark-mode .nH .AO::-webkit-scrollbar-thumb {
-  background-color: #323232 !important;
-  background: #323232 !important;
+  background-color: var(--dm-surface-raised) !important;
+  background: var(--dm-surface-raised) !important;
 }
 
 /* Override any default scrollbar colors */
@@ -3906,7 +3922,7 @@ body.dark-mode .nH .AO::-webkit-scrollbar {
 
   body.dark-mode .wT:hover,
   body.dark-mode .nH .AO:hover {
-    scrollbar-color: #323232 transparent !important;
+    scrollbar-color: var(--dm-surface-raised) transparent !important;
   }
 
   body.dark-mode .wT:not(:hover),
@@ -3962,13 +3978,13 @@ body.dark-mode .nH .AO::-webkit-scrollbar {
 }
 
 body.dark-mode .nH.ar4.C {
-  background-color: #141414 !important;
-  background: #141414 !important;
+  background-color: var(--dm-bg) !important;
+  background: var(--dm-bg) !important;
 }
 
 body.dark-mode .aUx {
-  background-color: #141414 !important;
-  background: #141414 !important;
+  background-color: var(--dm-bg) !important;
+  background: var(--dm-bg) !important;
 }
 
 /* Email row backgrounds - different colors for read vs unread */
@@ -3978,17 +3994,17 @@ body.dark-mode .aUx {
 /* Dark mode email styling - match light mode behavior exactly */
 body.dark-mode .zA {
   color: #e8eaed !important; /* Lighter text for better contrast */
-  background: #232323 !important; /* Dark background for read emails */
+  background: var(--dm-surface) !important; /* Dark background for read emails */
 }
 
 /* Unread emails - same background as light mode but darker */
 body.dark-mode .zA.zE {
-  background: #383838 !important; /* Darker background for unread emails */
+  background: var(--dm-hover) !important; /* Darker background for unread emails */
 }
 
 /* Hover state - same as light mode */
 body.dark-mode .zA:hover {
-  background: #2a2a2a !important; /* Slightly lighter on hover */
+  background: var(--dm-surface) !important; /* Slightly lighter on hover */
 }
 
 /* Removed duplicate rule - consolidated above */
@@ -4028,16 +4044,16 @@ body.dark-mode .zA .apU.xY .T-KT.xl::before {
 }
 
 body.dark-mode .brc {
-  background-color: #3b3b3b !important;
+  background-color: var(--dm-hover) !important;
   color: #fff !important;
 }
 
 body.dark-mode .calendar-attachment .event-time {
-  color: #c7c7c7 !important;
+  color: var(--dm-text-secondary) !important;
 }
 
 body.dark-mode .bundle-wrapper .label-link .bundle-count {
-  color: #c7c7c7 !important;
+  color: var(--dm-text-secondary) !important;
 }
 
 body.dark-mode .bundle-senders {
@@ -4072,7 +4088,7 @@ body.dark-mode .Yc {
 body.dark-mode .aHS-bnr .qj,
 body.dark-mode .aEc.aHS-bnr .qj,
 body.dark-mode .aEe {
-  background-color: #9f9f9f !important;
+  background-color: var(--dm-text-muted) !important;
   -webkit-mask-image: url('chrome-extension://__MSG_@@extension_id__/images/label_important_20dp_FFFFFF_FILL1_wght400_GRAD0_opsz20.svg') !important;
   mask-image: url('chrome-extension://__MSG_@@extension_id__/images/label_important_20dp_FFFFFF_FILL1_wght400_GRAD0_opsz20.svg') !important;
   -webkit-mask-size: 20px !important;
@@ -4086,7 +4102,7 @@ body.dark-mode .aEe {
 
 /* Dark mode overrides for specific icons - use #9f9f9f with proper mask-image to prevent Google icons showing through */
 body.dark-mode .aHS-bnu .qj {
-  background-color: #9f9f9f !important;
+  background-color: var(--dm-text-muted) !important;
   -webkit-mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_send_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
   mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_send_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
   -webkit-mask-size: 24px !important;
@@ -4099,7 +4115,7 @@ body.dark-mode .aHS-bnu .qj {
 }
 
 body.dark-mode .aHS-bnq .qj {
-  background-color: #9f9f9f !important;
+  background-color: var(--dm-text-muted) !important;
   -webkit-mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_drafts_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
   mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_drafts_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
   -webkit-mask-size: 24px !important;
@@ -4112,7 +4128,7 @@ body.dark-mode .aHS-bnq .qj {
 }
 
 body.dark-mode .aHS-aHO .qj {
-  background-color: #9f9f9f !important;
+  background-color: var(--dm-text-muted) !important;
   -webkit-mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_all_mail_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
   mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_all_mail_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
   -webkit-mask-size: 24px !important;
@@ -4125,7 +4141,7 @@ body.dark-mode .aHS-aHO .qj {
 }
 
 body.dark-mode .aHS-bnx .qj {
-  background-color: #9f9f9f !important;
+  background-color: var(--dm-text-muted) !important;
   -webkit-mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_trash_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
   mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_trash_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
   -webkit-mask-size: 24px !important;
@@ -4138,7 +4154,7 @@ body.dark-mode .aHS-bnx .qj {
 }
 
 body.dark-mode .aHS-bnv .qj {
-  background-color: #9f9f9f !important;
+  background-color: var(--dm-text-muted) !important;
   -webkit-mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_spam_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
   mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_spam_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
   -webkit-mask-size: 24px !important;
@@ -4151,7 +4167,7 @@ body.dark-mode .aHS-bnv .qj {
 }
 
 body.dark-mode .aHS-bns .qj {
-  background-color: #9f9f9f !important;
+  background-color: var(--dm-text-muted) !important;
   -webkit-mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_label_important_20dp_FFFFFF_FILL1_wght400_GRAD0_opsz20.svg') !important;
   mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_label_important_20dp_FFFFFF_FILL1_wght400_GRAD0_opsz20.svg') !important;
   -webkit-mask-size: 20px !important;
@@ -4164,7 +4180,7 @@ body.dark-mode .aHS-bns .qj {
 }
 
 body.dark-mode .aHS-nd .qj {
-  background-color: #9f9f9f !important;
+  background-color: var(--dm-text-muted) !important;
   -webkit-mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_schedule_send_20dp_FFFFFF_FILL1_wght400_GRAD0_opsz20.svg') !important;
   mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_schedule_send_20dp_FFFFFF_FILL1_wght400_GRAD0_opsz20.svg') !important;
   -webkit-mask-size: 20px !important;
@@ -4177,7 +4193,7 @@ body.dark-mode .aHS-nd .qj {
 }
 
 body.dark-mode .aHS-aHP .qj {
-  background-color: #9f9f9f !important;
+  background-color: var(--dm-text-muted) !important;
   -webkit-mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_chat_20dp_FFFFFF_FILL1_wght400_GRAD0_opsz20.svg') !important;
   mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_chat_20dp_FFFFFF_FILL1_wght400_GRAD0_opsz20.svg') !important;
   -webkit-mask-size: 20px !important;
@@ -4190,7 +4206,7 @@ body.dark-mode .aHS-aHP .qj {
 }
 
 body.dark-mode [data-tooltip='Categories'] .qj {
-  background-color: #9f9f9f !important;
+  background-color: var(--dm-text-muted) !important;
   -webkit-mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_categories_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
   mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_categories_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
   -webkit-mask-size: 24px !important;
@@ -4203,7 +4219,7 @@ body.dark-mode [data-tooltip='Categories'] .qj {
 }
 
 body.dark-mode [data-tooltip='Social'] .qj {
-  background-color: #9f9f9f !important;
+  background-color: var(--dm-text-muted) !important;
   -webkit-mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_social_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
   mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_social_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
   -webkit-mask-size: 24px !important;
@@ -4216,7 +4232,7 @@ body.dark-mode [data-tooltip='Social'] .qj {
 }
 
 body.dark-mode [data-tooltip='Updates'] .qj {
-  background-color: #9f9f9f !important;
+  background-color: var(--dm-text-muted) !important;
   -webkit-mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_updates_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
   mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_updates_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
   -webkit-mask-size: 24px !important;
@@ -4229,7 +4245,7 @@ body.dark-mode [data-tooltip='Updates'] .qj {
 }
 
 body.dark-mode [data-tooltip='Forums'] .qj {
-  background-color: #9f9f9f !important;
+  background-color: var(--dm-text-muted) !important;
   -webkit-mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_forums_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
   mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_forums_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
   -webkit-mask-size: 24px !important;
@@ -4242,7 +4258,7 @@ body.dark-mode [data-tooltip='Forums'] .qj {
 }
 
 body.dark-mode [data-tooltip='Promotions'] .qj {
-  background-color: #9f9f9f !important;
+  background-color: var(--dm-text-muted) !important;
   -webkit-mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_promotions_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
   mask-image: url('chrome-extension://__MSG_@@extension_id__/images/menu_promotions_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
   -webkit-mask-size: 24px !important;
@@ -4257,7 +4273,7 @@ body.dark-mode [data-tooltip='Promotions'] .qj {
 /* Firefox-specific dark mode overrides for all icons */
 @-moz-document url-prefix() {
   body.dark-mode .aHS-bnu .qj {
-    background-color: #9f9f9f !important;
+    background-color: var(--dm-text-muted) !important;
     -webkit-mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_send_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
     mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_send_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
     -webkit-mask-size: 24px !important;
@@ -4270,7 +4286,7 @@ body.dark-mode [data-tooltip='Promotions'] .qj {
   }
 
   body.dark-mode .aHS-bnq .qj {
-    background-color: #9f9f9f !important;
+    background-color: var(--dm-text-muted) !important;
     -webkit-mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_drafts_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
     mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_drafts_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
     -webkit-mask-size: 24px !important;
@@ -4283,7 +4299,7 @@ body.dark-mode [data-tooltip='Promotions'] .qj {
   }
 
   body.dark-mode .aHS-aHO .qj {
-    background-color: #9f9f9f !important;
+    background-color: var(--dm-text-muted) !important;
     -webkit-mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_all_mail_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
     mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_all_mail_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
     -webkit-mask-size: 24px !important;
@@ -4296,7 +4312,7 @@ body.dark-mode [data-tooltip='Promotions'] .qj {
   }
 
   body.dark-mode .aHS-bnx .qj {
-    background-color: #9f9f9f !important;
+    background-color: var(--dm-text-muted) !important;
     -webkit-mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_trash_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
     mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_trash_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
     -webkit-mask-size: 24px !important;
@@ -4309,7 +4325,7 @@ body.dark-mode [data-tooltip='Promotions'] .qj {
   }
 
   body.dark-mode .aHS-bnv .qj {
-    background-color: #9f9f9f !important;
+    background-color: var(--dm-text-muted) !important;
     -webkit-mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_spam_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
     mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_spam_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
     -webkit-mask-size: 24px !important;
@@ -4322,7 +4338,7 @@ body.dark-mode [data-tooltip='Promotions'] .qj {
   }
 
   body.dark-mode .aHS-bns .qj {
-    background-color: #9f9f9f !important;
+    background-color: var(--dm-text-muted) !important;
     -webkit-mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_label_important_20dp_FFFFFF_FILL1_wght400_GRAD0_opsz20.svg') !important;
     mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_label_important_20dp_FFFFFF_FILL1_wght400_GRAD0_opsz20.svg') !important;
     -webkit-mask-size: 20px !important;
@@ -4350,7 +4366,7 @@ body.dark-mode [data-tooltip='Promotions'] .qj {
   }
 
   body.dark-mode .aHS-nd .qj {
-    background-color: #9f9f9f !important;
+    background-color: var(--dm-text-muted) !important;
     -webkit-mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_schedule_send_20dp_FFFFFF_FILL1_wght400_GRAD0_opsz20.svg') !important;
     mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_schedule_send_20dp_FFFFFF_FILL1_wght400_GRAD0_opsz20.svg') !important;
     -webkit-mask-size: 20px !important;
@@ -4363,7 +4379,7 @@ body.dark-mode [data-tooltip='Promotions'] .qj {
   }
 
   body.dark-mode .aHS-aHP .qj {
-    background-color: #9f9f9f !important;
+    background-color: var(--dm-text-muted) !important;
     -webkit-mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_chat_20dp_FFFFFF_FILL1_wght400_GRAD0_opsz20.svg') !important;
     mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_chat_20dp_FFFFFF_FILL1_wght400_GRAD0_opsz20.svg') !important;
     -webkit-mask-size: 20px !important;
@@ -4379,7 +4395,7 @@ body.dark-mode [data-tooltip='Promotions'] .qj {
   body.dark-mode .aHS-bnr .qj,
   body.dark-mode .aEc.aHS-bnr .qj,
   body.dark-mode .aEe {
-    background-color: #9f9f9f !important;
+    background-color: var(--dm-text-muted) !important;
     -webkit-mask-image: url('moz-extension://__MSG_@@extension_id__/images/label_important_20dp_FFFFFF_FILL1_wght400_GRAD0_opsz20.svg') !important;
     mask-image: url('moz-extension://__MSG_@@extension_id__/images/label_important_20dp_FFFFFF_FILL1_wght400_GRAD0_opsz20.svg') !important;
     -webkit-mask-size: 20px !important;
@@ -4392,7 +4408,7 @@ body.dark-mode [data-tooltip='Promotions'] .qj {
   }
 
   body.dark-mode [data-tooltip='Categories'] .qj {
-    background-color: #9f9f9f !important;
+    background-color: var(--dm-text-muted) !important;
     -webkit-mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_categories_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
     mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_categories_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
     -webkit-mask-size: 24px !important;
@@ -4405,7 +4421,7 @@ body.dark-mode [data-tooltip='Promotions'] .qj {
   }
 
   body.dark-mode [data-tooltip='Social'] .qj {
-    background-color: #9f9f9f !important;
+    background-color: var(--dm-text-muted) !important;
     -webkit-mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_social_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
     mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_social_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
     -webkit-mask-size: 24px !important;
@@ -4418,7 +4434,7 @@ body.dark-mode [data-tooltip='Promotions'] .qj {
   }
 
   body.dark-mode [data-tooltip='Updates'] .qj {
-    background-color: #9f9f9f !important;
+    background-color: var(--dm-text-muted) !important;
     -webkit-mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_updates_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
     mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_updates_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
     -webkit-mask-size: 24px !important;
@@ -4431,7 +4447,7 @@ body.dark-mode [data-tooltip='Promotions'] .qj {
   }
 
   body.dark-mode [data-tooltip='Forums'] .qj {
-    background-color: #9f9f9f !important;
+    background-color: var(--dm-text-muted) !important;
     -webkit-mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_forums_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
     mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_forums_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
     -webkit-mask-size: 24px !important;
@@ -4444,7 +4460,7 @@ body.dark-mode [data-tooltip='Promotions'] .qj {
   }
 
   body.dark-mode [data-tooltip='Promotions'] .qj {
-    background-color: #9f9f9f !important;
+    background-color: var(--dm-text-muted) !important;
     -webkit-mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_promotions_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
     mask-image: url('moz-extension://__MSG_@@extension_id__/images/menu_promotions_24dp_FFFFFF_FILL1_wght400_GRAD0_opsz24.svg') !important;
     -webkit-mask-size: 24px !important;
@@ -4464,13 +4480,13 @@ body.dark-mode .wT > .n3 .byl:first-child .aim:first-child .nZ {
 body.dark-mode .aKk > tbody,
 .body.dark-mode .aAA,
 .body.dark-mode .aRz.J-KU {
-  background: #2a2a2a !important;
+  background: var(--dm-surface) !important;
 }
 
 /* Dark mode: highlight active sidebar menu item */
 body.dark-mode .TO.nZ {
   /* slightly lighter row for active state */
-  background-color: #383838 !important;
+  background-color: var(--dm-hover) !important;
 }
 
 /* Ensure the label text on the active row stays fully white */
@@ -4487,7 +4503,7 @@ body.dark-mode .G4,
 body.dark-mode .GR,
 body.dark-mode div[aria-label='Inbox tip'] {
   box-shadow:
-    0 -1px 0 #3b3b3b,
+    0 -1px 0 var(--dm-hover),
     0 0 2px rgb(0 0 0 / 32%),
     0 2px 4px rgb(0 0 0 / 44%) !important;
 }
@@ -4595,12 +4611,12 @@ body.dark-mode .vN {
 
 /* Make "Draft saved" text visible */
 body.dark-mode .aYF {
-  color: #8ab4f8 !important;
+  color: var(--dm-accent) !important;
 }
 
 /* Make toolbar dividers visible */
 body.dark-mode .oc {
-  border-color: #444 !important;
+  border-color: var(--dm-selected) !important;
 }
 
 /* Make dropdown menus readable - removed black background */
@@ -4609,7 +4625,7 @@ body.dark-mode .oc {
 
 /* Dark Mode Quick Settings Panel Fix */
 body.dark-mode .IU {
-  background-color: #141414 !important;
+  background-color: var(--dm-bg) !important;
 }
 
 /* Headers like "Quick settings", "Density", "Apps in Gmail" */
@@ -4627,13 +4643,13 @@ body.dark-mode .IU .ST   /* Checkbox labels */ {
 
 /* The container for each section */
 body.dark-mode fieldset.VM.aiL {
-  background-color: #252526 !important;
+  background-color: var(--dm-surface) !important;
 }
 
 /* Links like "Customize" and "View All" */
 body.dark-mode .IU .OD,
 body.dark-mode .IU .Tj {
-  color: #8ab4f8 !important;
+  color: var(--dm-accent) !important;
 }
 
 /* Invert icons and previews */
@@ -4656,7 +4672,7 @@ body.dark-mode .IU .Vo {
 }
 
 body.dark-mode .IU .Q1:checked + .Vo {
-  border-color: #8ab4f8 !important;
+  border-color: var(--dm-accent) !important;
 }
 
 body.dark-mode .IU .Q1:checked + .Vo::after {
@@ -4668,7 +4684,7 @@ body.dark-mode .IU .Q1:checked + .Vo::after {
   top: 2px;
   left: 2px;
   border-radius: 50%;
-  background-color: #8ab4f8 !important;
+  background-color: var(--dm-accent-surface) !important;
 }
 
 /* Checkbox Styling */
@@ -4677,13 +4693,13 @@ body.dark-mode .IU .SS + .ST::before {
 }
 
 body.dark-mode .IU .SS:checked + .ST::before {
-  background-color: #8ab4f8 !important;
-  border-color: #8ab4f8 !important;
+  background-color: var(--dm-accent-surface) !important;
+  border-color: var(--dm-accent) !important;
 }
 
 body.dark-mode .IU .SS:checked + .ST::after {
-  border-bottom: 2px solid #252526 !important;
-  border-right: 2px solid #252526 !important;
+  border-bottom: 2px solid var(--dm-surface) !important;
+  border-right: 2px solid var(--dm-surface) !important;
 }
 
 /* Remove the boxes around the radio button options */
@@ -4704,7 +4720,7 @@ body.dark-mode .IU .XK {
 /* Add a blue border to the selected image to indicate selection */
 body.dark-mode .IU input:checked ~ img {
   border-radius: 6px !important;
-  border: 2px solid #8ab4f8 !important;
+  border: 2px solid var(--dm-accent) !important;
 }
 
 /* Ensure the text part of a selected row has no special background or border */
@@ -4714,7 +4730,7 @@ body.dark-mode .IU input:checked ~ div {
 }
 
 body.dark-mode .IU .Q1:checked + .Vo {
-  border-color: #8ab4f8 !important;
+  border-color: var(--dm-accent) !important;
 }
 
 /* --- Final Attempt: Force remove borders from option labels --- */
@@ -4742,7 +4758,7 @@ body.dark-mode .Q1:checked + .Vo::after {
   width: 10px;
   height: 10px;
   border-radius: 50%;
-  background-color: #8ab4f8 !important;
+  background-color: var(--dm-accent-surface) !important;
   position: absolute;
   top: 50%;
   left: 50%;
@@ -4780,7 +4796,7 @@ body.dark-mode .Q1:checked + .Vo::after {
   width: 10px;
   height: 10px;
   border-radius: 50%;
-  background-color: #8ab4f8 !important;
+  background-color: var(--dm-accent-surface) !important;
   position: absolute;
   top: 50%;
   left: 50%;
@@ -4795,12 +4811,12 @@ body.dark-mode .nH.fY [role='presentation'] a.f0 {
 }
 
 body.dark-mode .nH.fY [role='presentation'] a.f0:hover {
-  color: #8ab4f8 !important;
+  color: var(--dm-accent) !important;
 }
 
 body.dark-mode .nH.fY [role='presentation'] a.f0[aria-selected='true'] {
-  color: #8ab4f8 !important;
-  border-bottom: 2px solid #8ab4f8 !important;
+  color: var(--dm-accent) !important;
+  border-bottom: 2px solid var(--dm-accent) !important;
 }
 
 body.dark-mode .nH.fY [role='presentation'] {
@@ -4809,7 +4825,7 @@ body.dark-mode .nH.fY [role='presentation'] {
 
 /* Dark Mode Theme Selection Dialog Styling */
 body.dark-mode .uW2Fw-bHo {
-  background-color: #252526 !important;
+  background-color: var(--dm-surface) !important;
   color: #e0e0e0 !important;
 }
 
@@ -4820,8 +4836,8 @@ body.dark-mode .uW2Fw-bHo .cER4xe {
 
 /* Theme preview containers */
 body.dark-mode .uW2Fw-bHo .a7H {
-  background-color: #141414 !important;
-  border: 1px solid #444 !important;
+  background-color: var(--dm-bg) !important;
+  border: 1px solid var(--dm-selected) !important;
 }
 
 /* Theme preview labels */
@@ -4835,36 +4851,36 @@ body.dark-mode .uW2Fw-bHo .a9J {
 
 /* Buttons styling */
 body.dark-mode .uW2Fw-bHo .mUIrbf-I {
-  background-color: #3a3a3a !important;
+  background-color: var(--dm-hover) !important;
   color: #e0e0e0 !important;
-  border: 1px solid #555 !important;
+  border: 1px solid var(--dm-border) !important;
 }
 
 body.dark-mode .uW2Fw-bHo .mUIrbf-I:hover {
-  background-color: #9f9f9f !important;
+  background-color: var(--dm-text-muted) !important;
 }
 
 body.dark-mode .uW2Fw-bHo .eV8l8d {
-  background-color: #8ab4f8 !important;
-  color: #252526 !important;
+  background-color: var(--dm-accent-surface) !important;
+  color: var(--dm-surface) !important;
 }
 
 /* More Images and My Photos buttons */
 body.dark-mode .uW2Fw-bHo .fQ1uhf,
 body.dark-mode .uW2Fw-bHo .PKBsLc button {
-  background-color: #141414 !important;
+  background-color: var(--dm-bg) !important;
   color: #e0e0e0 !important;
-  border: 1px solid #444 !important;
+  border: 1px solid var(--dm-selected) !important;
 }
 
 body.dark-mode .uW2Fw-bHo .fQ1uhf:hover,
 body.dark-mode .uW2Fw-bHo .PKBsLc button:hover {
-  background-color: #3a3a3a !important;
+  background-color: var(--dm-hover) !important;
 }
 
 /* Dark Mode Theme Selection Dialog Enhanced Styling */
 body.dark-mode .uW2Fw-bHo {
-  background-color: #252526 !important;
+  background-color: var(--dm-surface) !important;
   color: #e0e0e0 !important;
 }
 
@@ -4875,8 +4891,8 @@ body.dark-mode .uW2Fw-bHo .cER4xe {
 
 /* Custom theme preview containers */
 body.dark-mode .uW2Fw-bHo .a7H {
-  background-color: #141414 !important;
-  border: 1px solid #444 !important;
+  background-color: var(--dm-bg) !important;
+  border: 1px solid var(--dm-selected) !important;
   transition: transform 0.2s ease;
 }
 
@@ -4907,24 +4923,24 @@ body.dark-mode .uW2Fw-bHo .a9J {
 
 /* Buttons styling - More prominent and clear */
 body.dark-mode .uW2Fw-bHo .mUIrbf-I {
-  background-color: #3a3a3a !important;
+  background-color: var(--dm-hover) !important;
   color: #e0e0e0 !important;
-  border: 1px solid #555 !important;
+  border: 1px solid var(--dm-border) !important;
   transition:
     background-color 0.2s ease,
     color 0.2s ease;
 }
 
 body.dark-mode .uW2Fw-bHo .mUIrbf-I:hover {
-  background-color: #9f9f9f !important;
+  background-color: var(--dm-text-muted) !important;
   color: white !important;
 }
 
 /* Save button - more prominent */
 body.dark-mode .uW2Fw-bHo .eV8l8d {
-  background-color: #8ab4f8 !important;
+  background-color: var(--dm-accent-surface) !important;
   color: white !important;
-  border: 1px solid #8ab4f8 !important;
+  border: 1px solid var(--dm-accent) !important;
   font-weight: bold;
 }
 
@@ -4935,15 +4951,15 @@ body.dark-mode .uW2Fw-bHo .eV8l8d:hover {
 /* More Images and My Photos buttons */
 body.dark-mode .uW2Fw-bHo .fQ1uhf,
 body.dark-mode .uW2Fw-bHo .PKBsLc button {
-  background-color: #141414 !important;
+  background-color: var(--dm-bg) !important;
   color: #e0e0e0 !important;
-  border: 1px solid #444 !important;
+  border: 1px solid var(--dm-selected) !important;
   transition: background-color 0.2s ease;
 }
 
 body.dark-mode .uW2Fw-bHo .fQ1uhf:hover,
 body.dark-mode .uW2Fw-bHo .PKBsLc button:hover {
-  background-color: #3a3a3a !important;
+  background-color: var(--dm-hover) !important;
   color: white !important;
 }
 
@@ -4965,15 +4981,15 @@ body.dark-mode .uW2Fw-bHo .a7N {
 
 /* Buttons with high contrast */
 body.dark-mode .uW2Fw-bHo .mUIrbf-I {
-  background-color: #3a3a3a !important;
+  background-color: var(--dm-hover) !important;
   color: #fff !important;
   border: 1px solid #666 !important;
 }
 
 body.dark-mode .uW2Fw-bHo .eV8l8d {
-  background-color: #4285f4 !important;
+  background-color: var(--dm-accent-strong) !important;
   color: white !important;
-  border: 1px solid #4285f4 !important;
+  border: 1px solid var(--dm-accent) !important;
 }
 
 body.dark-mode .uW2Fw-bHo .mUIrbf-I:hover,
@@ -5024,16 +5040,16 @@ body.dark-mode .uW2Fw-bHo .a9J {
 /* Button Styling with Maximum Contrast */
 body.dark-mode .uW2Fw-bHo .mUIrbf-I,
 body.dark-mode .uW2Fw-bHo .PKBsLc button {
-  background-color: #3a3a3a !important;
+  background-color: var(--dm-hover) !important;
   color: #fff !important;
   border: 1px solid #666 !important;
   transition: all 0.2s ease !important;
 }
 
 body.dark-mode .uW2Fw-bHo .eV8l8d {
-  background-color: #4285f4 !important;
+  background-color: var(--dm-accent-strong) !important;
   color: white !important;
-  border: 1px solid #4285f4 !important;
+  border: 1px solid var(--dm-accent) !important;
   font-weight: bold !important;
 }
 
@@ -5050,14 +5066,14 @@ body.dark-mode .uW2Fw-bHo .a7C {
 
 /* More Images section */
 body.dark-mode .uW2Fw-bHo .fQ1uhf {
-  background-color: #141414 !important;
+  background-color: var(--dm-bg) !important;
   color: #fff !important;
-  border: 1px solid #444 !important;
+  border: 1px solid var(--dm-selected) !important;
 }
 
 /* Dark Mode Theme Selection Dialog Fix */
 body.dark-mode .uW2Fw-bHo {
-  background-color: #252526 !important;
+  background-color: var(--dm-surface) !important;
   color: #fff !important;
 }
 
@@ -5086,21 +5102,21 @@ body.dark-mode .uW2Fw-bHo .a9J {
 }
 
 body.dark-mode .uW2Fw-bHo .mUIrbf-I {
-  background-color: #3a3a3a !important;
+  background-color: var(--dm-hover) !important;
   color: #fff !important;
-  border: 1px solid #555 !important;
+  border: 1px solid var(--dm-border) !important;
 }
 
 body.dark-mode .uW2Fw-bHo .eV8l8d {
-  background-color: #4285f4 !important;
+  background-color: var(--dm-accent-strong) !important;
   color: white !important;
-  border: 1px solid #4285f4 !important;
+  border: 1px solid var(--dm-accent) !important;
 }
 
 body.dark-mode .uW2Fw-bHo .fQ1uhf {
-  background-color: #141414 !important;
+  background-color: var(--dm-bg) !important;
   color: #fff !important;
-  border: 1px solid #444 !important;
+  border: 1px solid var(--dm-selected) !important;
 }
 
 body.dark-mode .uW2Fw-bHo .cER4xe {
@@ -5171,8 +5187,8 @@ body.dark-mode .a3I {
 body.dark-mode .no,
 body.dark-mode .nH.bkK.nn + .nH.nn,
 body.dark-mode [aria-label='Hangouts'][role='complementary'] {
-  background-color: #141414 !important;
-  background: #141414 !important;
+  background-color: var(--dm-bg) !important;
+  background: var(--dm-bg) !important;
 }
 
 /* Force menu background to be #141414 - COMPREHENSIVE APPROACH */
@@ -5198,8 +5214,8 @@ body.dark-mode .aZ6,
 body.dark-mode .pp,
 body.dark-mode .nM,
 body.dark-mode .yJ {
-  background-color: #141414 !important;
-  background: #141414 !important;
+  background-color: var(--dm-bg) !important;
+  background: var(--dm-bg) !important;
 }
 
 /* Force Categories icon to work properly */
@@ -5212,7 +5228,7 @@ body.dark-mode [data-tooltip='Categories'] .aEc.aHS-bnr .qj {
   mask-repeat: no-repeat !important;
   -webkit-mask-position: center !important;
   mask-position: center !important;
-  background-color: #9f9f9f !important;
+  background-color: var(--dm-text-muted) !important;
   background-image: none !important;
 }
 
@@ -5227,7 +5243,7 @@ body.dark-mode [data-tooltip='Categories'] .aEc.aHS-bnr .qj {
     mask-repeat: no-repeat !important;
     -webkit-mask-position: center !important;
     mask-position: center !important;
-    background-color: #9f9f9f !important;
+    background-color: var(--dm-text-muted) !important;
     background-image: none !important;
   }
 }


### PR DESCRIPTION
## Summary
- Add ESLint, Stylelint, and Prettier with `npm run lint`, plus a GitHub Actions CI workflow
- Format the entire source with Prettier/Stylelint and remove dead code
- Dark mode overhaul: OWA-inspired palette variables, dark reading pane, dark compose
- Slim the store zip package and remove unused files

## Testing
- Verified on Chrome (lint passing, builds produced for both browsers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)